### PR TITLE
Legg til antall tapte dagsverk gradert i både Næringskode og Bransje

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -65,7 +65,7 @@ jobs:
       id-token: write
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/utled-aggregert-statistikk'
+    if: github.ref == 'refs/heads/tapte-dv-for-bransje'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/persistering/SykefraværsstatistikkDto.kt
+++ b/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/persistering/SykefraværsstatistikkDto.kt
@@ -29,6 +29,10 @@ sealed interface KvartalsvisSykefraværsstatistikk {
     val antallPersoner: Int
 }
 
+interface KvartalsvisSykefraværsstatistikkMedGradering {
+    val tapteDagsverkGradert: BigDecimal
+}
+
 @Serializable(with = SykefraværsstatistikkDtoSerializer::class)
 sealed class SykefraværsstatistikkDto : KvartalsvisSykefraværsstatistikk {
     abstract override val årstall: Int
@@ -79,11 +83,12 @@ data class NæringSykefraværsstatistikkDto(
     @Serializable(with = BigDecimalSerializer::class)
     override val muligeDagsverk: BigDecimal,
     @Serializable(with = BigDecimalSerializer::class)
-    val tapteDagsverkGradert: BigDecimal,
+    override val tapteDagsverkGradert: BigDecimal,
     @Serializable(with = TapteDagsverkPerVarighetListSerializer::class)
     val tapteDagsverkPerVarighet: List<TapteDagsverkPerVarighetDto>,
     override val antallPersoner: Int,
-) : SykefraværsstatistikkDto()
+) : SykefraværsstatistikkDto(),
+    KvartalsvisSykefraværsstatistikkMedGradering
 
 @Serializable
 data class NæringskodeSykefraværsstatistikkDto(
@@ -115,11 +120,12 @@ data class BransjeSykefraværsstatistikkDto(
     @Serializable(with = BigDecimalSerializer::class)
     override val muligeDagsverk: BigDecimal,
     @Serializable(with = BigDecimalSerializer::class)
-    val tapteDagsverkGradert: BigDecimal,
+    override val tapteDagsverkGradert: BigDecimal,
     @Serializable(with = TapteDagsverkPerVarighetListSerializer::class)
     val tapteDagsverkPerVarighet: List<TapteDagsverkPerVarighetDto>,
     override val antallPersoner: Int,
-) : SykefraværsstatistikkDto()
+) : SykefraværsstatistikkDto(),
+    KvartalsvisSykefraværsstatistikkMedGradering
 
 @Serializable
 data class VirksomhetSykefraværsstatistikkDto(

--- a/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/persistering/SykefraværsstatistikkDto.kt
+++ b/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/persistering/SykefraværsstatistikkDto.kt
@@ -102,11 +102,12 @@ data class NæringskodeSykefraværsstatistikkDto(
     @Serializable(with = BigDecimalSerializer::class)
     override val muligeDagsverk: BigDecimal,
     @Serializable(with = BigDecimalSerializer::class)
-    val tapteDagsverkGradert: BigDecimal,
+    override val tapteDagsverkGradert: BigDecimal,
     @Serializable(with = TapteDagsverkPerVarighetListSerializer::class)
     val tapteDagsverkPerVarighet: List<TapteDagsverkPerVarighetDto>,
     override val antallPersoner: Int,
-) : SykefraværsstatistikkDto()
+) : SykefraværsstatistikkDto(),
+    KvartalsvisSykefraværsstatistikkMedGradering
 
 @Serializable
 data class BransjeSykefraværsstatistikkDto(

--- a/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/persistering/SykefraværsstatistikkGraderingRepository.kt
+++ b/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/persistering/SykefraværsstatistikkGraderingRepository.kt
@@ -25,12 +25,12 @@ class SykefraværsstatistikkGraderingRepository(
 ) {
     private val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
-    fun hentForNæring(næring: Næring): List<UmaskertSykefraværUtenProsentForEttKvartal> = hentGradertSykefravær(næring)
+    fun hentForNæring(næring: Næring): List<UmaskertSykefraværUtenProsentForEttKvartal> = hentGradertSykefravær(næring = næring)
 
-    @Deprecated("Bransje har ikke fått enda tapte_dagsverk_gradert")
-    fun hentForBransje(bransje: Bransje): List<UmaskertSykefraværUtenProsentForEttKvartal> = emptyList()
+    fun hentForBransje(bransje: Bransje): List<UmaskertSykefraværUtenProsentForEttKvartal> = hentGradertSykefravær(bransje = bransje)
 
-    fun hentForVirksomhet(virksomhet: Virksomhet): List<UmaskertSykefraværUtenProsentForEttKvartal> = hentGradertSykefravær(virksomhet)
+    fun hentForVirksomhet(virksomhet: Virksomhet): List<UmaskertSykefraværUtenProsentForEttKvartal> =
+        hentGradertSykefravær(virksomhet = virksomhet)
 
     private fun hentGradertSykefravær(næring: Næring): List<UmaskertSykefraværUtenProsentForEttKvartal> =
         try {
@@ -47,7 +47,6 @@ class SykefraværsstatistikkGraderingRepository(
             throw e
         }
 
-    @Deprecated("Bransje har ikke fått enda tapte_dagsverk_gradert")
     private fun hentGradertSykefravær(bransje: Bransje): List<UmaskertSykefraværUtenProsentForEttKvartal> =
         try {
             using(sessionOf(dataSource)) { session ->

--- a/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/persistering/SykefraværsstatistikkRepository.kt
+++ b/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/persistering/SykefraværsstatistikkRepository.kt
@@ -94,7 +94,7 @@ class SykefraværsstatistikkRepository(
             }
 
             is NæringskodeSykefraværsstatistikkDto -> {
-                insertSykefraværsstatistikk(
+                insertSykefraværsstatistikkMedGradering(
                     sykefraværsstatistikkDto = sykefraværsstatistikkDto,
                 )
                 insertTapteDagsverkPerVarighetForKategori(

--- a/src/main/resources/db/migration/2025/V10__tapte_dagsverk_gradert_for_naringskode.sql
+++ b/src/main/resources/db/migration/2025/V10__tapte_dagsverk_gradert_for_naringskode.sql
@@ -1,0 +1,7 @@
+ALTER TABLE sykefravarsstatistikk_naringskode
+    ADD COLUMN tapte_dagsverk_gradert numeric(17, 6);
+
+UPDATE sykefravarsstatistikk_naringskode set tapte_dagsverk_gradert = 0 where tapte_dagsverk_gradert is null;
+
+ALTER TABLE sykefravarsstatistikk_naringskode
+    ALTER COLUMN tapte_dagsverk_gradert set not null;

--- a/src/main/resources/db/migration/2025/V9__tapte_dagsverk_gradert_for_bransje.sql
+++ b/src/main/resources/db/migration/2025/V9__tapte_dagsverk_gradert_for_bransje.sql
@@ -1,0 +1,7 @@
+ALTER TABLE sykefravarsstatistikk_bransje
+    ADD COLUMN tapte_dagsverk_gradert numeric(17, 6);
+
+UPDATE sykefravarsstatistikk_bransje set tapte_dagsverk_gradert = 0 where tapte_dagsverk_gradert is null;
+
+ALTER TABLE sykefravarsstatistikk_bransje
+    ALTER COLUMN tapte_dagsverk_gradert set not null;

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/SykefraværsstatistikkApiEndepunkterIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/SykefraværsstatistikkApiEndepunkterIntegrasjonsTest.kt
@@ -81,8 +81,7 @@ class SykefraværsstatistikkApiEndepunkterIntegrasjonsTest {
 
             listOf(
                 aggregertStatistikk.prosentSiste4KvartalerTotalt,
-                // TODO: vi har ikke gradert for bransje enda
-                // aggregertStatistikk.prosentSiste4KvartalerGradert,
+                aggregertStatistikk.prosentSiste4KvartalerGradert,
                 aggregertStatistikk.prosentSiste4KvartalerKorttid,
                 aggregertStatistikk.prosentSiste4KvartalerLangtid,
                 aggregertStatistikk.trendTotalt,

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/helper/SykefraværsstatistikkImportTestUtils.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/helper/SykefraværsstatistikkImportTestUtils.kt
@@ -20,6 +20,18 @@ class SykefraværsstatistikkImportTestUtils {
         val antallPersoner: Int,
     )
 
+    data class StatistikkGjeldendeKvartalMedGradering(
+        val kategori: Statistikkategori,
+        val kode: String,
+        val årstall: Int,
+        val kvartal: Int,
+        val tapteDagsverk: BigDecimal,
+        val muligeDagsverk: BigDecimal,
+        val prosent: BigDecimal,
+        val tapteDagsverkGradert: BigDecimal,
+        val antallPersoner: Int,
+    )
+
     data class VirksomhetStatistikk(
         val orgnr: String,
         val årstall: Int,
@@ -206,6 +218,38 @@ class SykefraværsstatistikkImportTestUtils {
                     prosent = rs.getBigDecimal("prosent"),
                     tapteDagsverk = rs.getBigDecimal("tapte_dagsverk"),
                     muligeDagsverk = rs.getBigDecimal("mulige_dagsverk"),
+                    antallPersoner = rs.getInt("antall_personer"),
+                )
+            }
+        }
+
+        fun hentStatistikkGjeldendeKvartalMedGradering(
+            kategori: Statistikkategori,
+            verdi: String,
+            kvartal: ÅrstallOgKvartal,
+            tabellnavn: String,
+            kodenavn: String,
+        ): StatistikkGjeldendeKvartalMedGradering {
+            val query = """
+            select * from $tabellnavn 
+             where $kodenavn = '$verdi'
+             and arstall = ${kvartal.årstall} and kvartal = ${kvartal.kvartal}
+            """.trimMargin()
+            TestContainerHelper.postgresContainerHelper.dataSource.connection.use { connection ->
+                val statement = connection.createStatement()
+                statement.execute(query)
+                val rs = statement.resultSet
+                rs.next()
+                rs.row shouldBe 1
+                return StatistikkGjeldendeKvartalMedGradering(
+                    kategori = kategori,
+                    kode = rs.getString(kodenavn),
+                    årstall = rs.getInt("arstall"),
+                    kvartal = rs.getInt("kvartal"),
+                    prosent = rs.getBigDecimal("prosent"),
+                    tapteDagsverk = rs.getBigDecimal("tapte_dagsverk"),
+                    muligeDagsverk = rs.getBigDecimal("mulige_dagsverk"),
+                    tapteDagsverkGradert = rs.getBigDecimal("tapte_dagsverk_gradert"),
                     antallPersoner = rs.getInt("antall_personer"),
                 )
             }

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/importering/KvartalsvisSykefraværsstatistikkØvrigeKategorierConsumerTest.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/importering/KvartalsvisSykefraværsstatistikkØvrigeKategorierConsumerTest.kt
@@ -5,6 +5,7 @@ import no.nav.pia.sykefravarsstatistikk.domene.Statistikkategori
 import no.nav.pia.sykefravarsstatistikk.helper.SykefraværsstatistikkImportTestUtils.Companion.KVARTAL_2024_3
 import no.nav.pia.sykefravarsstatistikk.helper.SykefraværsstatistikkImportTestUtils.Companion.bigDecimalShouldBe
 import no.nav.pia.sykefravarsstatistikk.helper.SykefraværsstatistikkImportTestUtils.Companion.hentStatistikkGjeldendeKvartal
+import no.nav.pia.sykefravarsstatistikk.helper.SykefraværsstatistikkImportTestUtils.Companion.hentStatistikkGjeldendeKvartalMedGradering
 import no.nav.pia.sykefravarsstatistikk.helper.SykefraværsstatistikkImportTestUtils.Companion.hentStatistikkMedVarighet
 import no.nav.pia.sykefravarsstatistikk.helper.SykefraværsstatistikkImportTestUtils.JsonMelding
 import no.nav.pia.sykefravarsstatistikk.helper.SykefraværsstatistikkImportTestUtils.TapteDagsverkPerVarighet
@@ -86,8 +87,8 @@ class KvartalsvisSykefraværsstatistikkØvrigeKategorierConsumerTest {
             prosent = 2.7.toBigDecimal(),
             tapteDagsverk = 5039.8.toBigDecimal(),
             muligeDagsverk = 186.3.toBigDecimal(),
-            antallPersoner = 3,
-            tapteDagsverGradert = 0.0.toBigDecimal(),
+            antallPersoner = 5,
+            tapteDagsverGradert = 87.87601.toBigDecimal(),
             tapteDagsverkMedVarighet = listOf(
                 TapteDagsverkPerVarighet(
                     varighet = "A",
@@ -105,7 +106,7 @@ class KvartalsvisSykefraværsstatistikkØvrigeKategorierConsumerTest {
             KafkaTopics.KVARTALSVIS_SYKEFRAVARSSTATISTIKK_ØVRIGE_KATEGORIER,
         )
 
-        val statistikkQ32024 = hentStatistikkGjeldendeKvartal(
+        val statistikkQ32024 = hentStatistikkGjeldendeKvartalMedGradering(
             kategori = Statistikkategori.NÆRING,
             verdi = "22",
             kvartal = KVARTAL_2024_3,
@@ -114,7 +115,11 @@ class KvartalsvisSykefraværsstatistikkØvrigeKategorierConsumerTest {
         )
         statistikkQ32024.kategori shouldBe Statistikkategori.NÆRING
         statistikkQ32024.kode shouldBe "22"
+        statistikkQ32024.muligeDagsverk bigDecimalShouldBe 186.3
+        statistikkQ32024.prosent bigDecimalShouldBe 2.7
+        statistikkQ32024.antallPersoner shouldBe 5
         statistikkQ32024.tapteDagsverk bigDecimalShouldBe 5039.8
+        statistikkQ32024.tapteDagsverkGradert bigDecimalShouldBe 87.87601
 
         val statistikkMedVarighet = hentStatistikkMedVarighet(
             tabellnavn = "sykefravarsstatistikk_naring_med_varighet",
@@ -191,7 +196,7 @@ class KvartalsvisSykefraværsstatistikkØvrigeKategorierConsumerTest {
             tapteDagsverk = 5039.8.toBigDecimal(),
             muligeDagsverk = 186.3.toBigDecimal(),
             antallPersoner = 3,
-            tapteDagsverGradert = 0.0.toBigDecimal(),
+            tapteDagsverGradert = 21.2345.toBigDecimal(),
             tapteDagsverkMedVarighet = listOf(
                 TapteDagsverkPerVarighet(
                     varighet = "A",
@@ -209,7 +214,7 @@ class KvartalsvisSykefraværsstatistikkØvrigeKategorierConsumerTest {
             KafkaTopics.KVARTALSVIS_SYKEFRAVARSSTATISTIKK_ØVRIGE_KATEGORIER,
         )
 
-        val statistikkQ32024 = hentStatistikkGjeldendeKvartal(
+        val statistikkQ32024 = hentStatistikkGjeldendeKvartalMedGradering(
             kategori = Statistikkategori.BRANSJE,
             verdi = "22",
             kvartal = KVARTAL_2024_3,
@@ -221,6 +226,7 @@ class KvartalsvisSykefraværsstatistikkØvrigeKategorierConsumerTest {
         statistikkQ32024.kode shouldBe "22"
         statistikkQ32024.tapteDagsverk bigDecimalShouldBe 5039.8
         statistikkQ32024.muligeDagsverk bigDecimalShouldBe 186.3
+        statistikkQ32024.tapteDagsverkGradert bigDecimalShouldBe 21.2345
         statistikkQ32024.prosent bigDecimalShouldBe 2.7
         statistikkQ32024.antallPersoner shouldBe 3
 

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/importering/KvartalsvisSykefraværsstatistikkØvrigeKategorierConsumerTest.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/importering/KvartalsvisSykefraværsstatistikkØvrigeKategorierConsumerTest.kt
@@ -160,7 +160,7 @@ class KvartalsvisSykefraværsstatistikkØvrigeKategorierConsumerTest {
             KafkaTopics.KVARTALSVIS_SYKEFRAVARSSTATISTIKK_ØVRIGE_KATEGORIER,
         )
 
-        val statistikkQ32024 = hentStatistikkGjeldendeKvartal(
+        val statistikkQ32024 = hentStatistikkGjeldendeKvartalMedGradering(
             kategori = Statistikkategori.NÆRINGSKODE,
             verdi = "88911",
             kvartal = KVARTAL_2024_3,
@@ -172,6 +172,7 @@ class KvartalsvisSykefraværsstatistikkØvrigeKategorierConsumerTest {
         statistikkQ32024.kode shouldBe "88911"
         statistikkQ32024.tapteDagsverk bigDecimalShouldBe 17.5
         statistikkQ32024.muligeDagsverk bigDecimalShouldBe 761.3
+        statistikkQ32024.tapteDagsverkGradert bigDecimalShouldBe 19.2
         statistikkQ32024.prosent bigDecimalShouldBe 2.3
         statistikkQ32024.antallPersoner shouldBe 4
 


### PR DESCRIPTION
Lagring av tapte_dagsverk_gradert for både bransje og næringskode
- opprette nye felter i DB
- ta i bruk feltet ved endepunkt /aggregert 