### PR TITLE
Håndtere overordnet enhet uten institusjonell sektor kode

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -65,7 +65,7 @@ jobs:
       id-token: write
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/maskert-kvartalsvisstatistikk'
+    if: github.ref == 'refs/heads/overordnet-enhet-uten-sektor'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/api/dto/BrregEnhetDto.kt
+++ b/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/api/dto/BrregEnhetDto.kt
@@ -13,7 +13,7 @@ data class BrregEnhetDto(
     val naeringskode1: BrregNæringskodeDto,
     val overordnetEnhet: String? = null,
     val antallAnsatte: Int = 0,
-    val institusjonellSektorkode: BrregInstitusjonellSektorkodeDto,
+    val institusjonellSektorkode: BrregInstitusjonellSektorkodeDto? = null,
 ) {
     fun tilDomene(): OverordnetEnhet =
         OverordnetEnhet(
@@ -21,6 +21,6 @@ data class BrregEnhetDto(
             navn = this.navn,
             næringskode = this.naeringskode1.tilDomene(),
             antallAnsatte = this.antallAnsatte,
-            sektor = this.institusjonellSektorkode.tilDomene(),
+            sektor = this.institusjonellSektorkode?.tilDomene(),
         )
 }

--- a/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/api/dto/BrregUnderenhetDto.kt
+++ b/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/api/dto/BrregUnderenhetDto.kt
@@ -14,6 +14,7 @@ data class BrregUnderenhetDto(
     val antallAnsatte: Int = 0,
 ) {
     fun tilDomene(): Underenhet =
+        // TODO: håndtere ikke-næringsdrivende virksomhet
         if (naeringskode1 != null) {
             Underenhet.Næringsdrivende(
                 orgnr = organisasjonsnummer,

--- a/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/domene/OverordnetEnhet.kt
+++ b/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/domene/OverordnetEnhet.kt
@@ -5,5 +5,5 @@ class OverordnetEnhet(
     override val navn: String,
     override val næringskode: Næringskode,
     override val antallAnsatte: Int,
-    val sektor: Sektor,
+    val sektor: Sektor? = null,
 ) : Virksomhet

--- a/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/persistering/KvartalsvisSykefraværshistorikkService.kt
+++ b/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/persistering/KvartalsvisSykefraværshistorikkService.kt
@@ -123,6 +123,7 @@ class KvartalsvisSykefraværshistorikkService(
         val umaskertLandstatistikk = hentSykefraværsstatistikkLand(
             førsteKvartal,
         ).ifEmpty {
+            logger.warn("Ingen landstatistikk funnet fra årstal/kvartal '$førsteKvartal'")
             return Feil(
                 feilmelding = "Ingen landstatistikk funnet",
                 httpStatusCode = HttpStatusCode.BadRequest,
@@ -135,6 +136,9 @@ class KvartalsvisSykefraværshistorikkService(
                 sektor = overordnetEnhet.sektor,
                 førsteÅrstalOgKvartal = førsteKvartal,
             ).ifEmpty {
+                logger.warn(
+                    "Ingen sektorstatistikk funnet for sektor '${overordnetEnhet.sektor.beskrivelse}' fra årstal/kvartal '$førsteKvartal'",
+                )
                 return Feil(
                     feilmelding = "Ingen sektorstatistikk funnet",
                     httpStatusCode = HttpStatusCode.BadRequest,
@@ -163,6 +167,7 @@ class KvartalsvisSykefraværshistorikkService(
                     bransje = bransje,
                     førsteÅrstalOgKvartal = førsteKvartal,
                 ).ifEmpty {
+                    logger.warn("Ingen bransjestatistikk funnet for bransje '${bransje.navn}' fra årstal/kvartal '$førsteKvartal'")
                     return Feil(
                         feilmelding = "Ingen bransjestatistikk funnet for bransje '${bransje.navn}'",
                         httpStatusCode = HttpStatusCode.BadRequest,
@@ -174,6 +179,9 @@ class KvartalsvisSykefraværshistorikkService(
                     næring = underenhet.næringskode.næring,
                     førsteÅrstalOgKvartal = førsteKvartal,
                 ).ifEmpty {
+                    logger.warn(
+                        "Ingen næringsstatistikk funnet for næring '${underenhet.næringskode.næring.tosifferIdentifikator}-${underenhet.næringskode.næring.navn}' fra årstal/kvartal '$førsteKvartal'",
+                    )
                     return Feil(
                         feilmelding = "Ingen næringsstatistikk funnet for næring " +
                             "med navn: '${underenhet.næringskode.næring.navn}' " +

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/EdgeCasesSykefraværsstatistikkApiEndepunkterTest.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/EdgeCasesSykefraværsstatistikkApiEndepunkterTest.kt
@@ -15,8 +15,8 @@ import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.kaf
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.postgresContainerHelper
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3
-import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.overordnetEnhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode
-import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode
+import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.overordnetEnhetIBransjeByggUtenInstitusjonellSektorKode
+import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.underenhetIBransjeByggUtenInstitusjonellSektorKode
 import no.nav.pia.sykefravarsstatistikk.helper.withToken
 import no.nav.pia.sykefravarsstatistikk.persistering.INGEN_SEKTOR_LABEL
 import kotlin.test.BeforeTest
@@ -38,22 +38,22 @@ class EdgeCasesSykefraværsstatistikkApiEndepunkterTest {
     fun `Virksomhet uten institusjonell sektor kode fungerer både for aggregert og kvartalsvis`() {
         runBlocking {
             kafkaContainerHelper.sendStatistikk(
-                overordnetEnhet = overordnetEnhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode,
-                underenhet = underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode,
+                overordnetEnhet = overordnetEnhetIBransjeByggUtenInstitusjonellSektorKode,
+                underenhet = underenhetIBransjeByggUtenInstitusjonellSektorKode,
             )
 
             altinnTilgangerContainerHelper.leggTilRettigheter(
-                underenhet = underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode,
+                underenhet = underenhetIBransjeByggUtenInstitusjonellSektorKode,
                 altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
 
             val aggregertStatistikkDto = TestContainerHelper.hentAggregertStatistikk(
-                orgnr = underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode.orgnr,
+                orgnr = underenhetIBransjeByggUtenInstitusjonellSektorKode.orgnr,
                 config = withToken(),
             )
 
-            val bransje = underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode.bransje()!!
+            val bransje = underenhetIBransjeByggUtenInstitusjonellSektorKode.bransje()!!
 
             val landStatistikk = aggregertStatistikkDto.prosentSiste4KvartalerTotalt
                 .firstOrNull { it.statistikkategori == LAND }
@@ -68,10 +68,10 @@ class EdgeCasesSykefraværsstatistikkApiEndepunkterTest {
             val virksomhetStatistikk = aggregertStatistikkDto.prosentSiste4KvartalerTotalt
                 .firstOrNull { it.statistikkategori == VIRKSOMHET }
             virksomhetStatistikk.shouldNotBeNull()
-            virksomhetStatistikk.label shouldBe underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode.navn
+            virksomhetStatistikk.label shouldBe underenhetIBransjeByggUtenInstitusjonellSektorKode.navn
 
             val kvartalsvisStatistikkDto = TestContainerHelper.hentKvartalsvisStatistikk(
-                orgnr = underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode.orgnr,
+                orgnr = underenhetIBransjeByggUtenInstitusjonellSektorKode.orgnr,
                 config = withToken(),
             )
 

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/EdgeCasesSykefraværsstatistikkApiEndepunkterTest.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/EdgeCasesSykefraværsstatistikkApiEndepunkterTest.kt
@@ -1,0 +1,87 @@
+package no.nav.pia.sykefravarsstatistikk.api
+
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.runBlocking
+import no.nav.pia.sykefravarsstatistikk.domene.Statistikkategori.BRANSJE
+import no.nav.pia.sykefravarsstatistikk.domene.Statistikkategori.LAND
+import no.nav.pia.sykefravarsstatistikk.domene.Statistikkategori.NÆRING
+import no.nav.pia.sykefravarsstatistikk.domene.Statistikkategori.SEKTOR
+import no.nav.pia.sykefravarsstatistikk.domene.Statistikkategori.VIRKSOMHET
+import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper
+import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.altinnTilgangerContainerHelper
+import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.kafkaContainerHelper
+import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.postgresContainerHelper
+import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2
+import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3
+import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.overordnetEnhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode
+import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode
+import no.nav.pia.sykefravarsstatistikk.helper.withToken
+import no.nav.pia.sykefravarsstatistikk.persistering.INGEN_SEKTOR_LABEL
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+class EdgeCasesSykefraværsstatistikkApiEndepunkterTest {
+    @BeforeTest
+    fun cleanUp() {
+        runBlocking {
+            altinnTilgangerContainerHelper.slettAlleRettigheter()
+            postgresContainerHelper.slettAlleStatistikk()
+        }
+    }
+
+    /*
+       Data fra enhetsregisteret kan mangle noe informasjon, som for eksempel institusjonell sektor kode.
+     * */
+    @Test
+    fun `Virksomhet uten institusjonell sektor kode fungerer både for aggregert og kvartalsvis`() {
+        runBlocking {
+            kafkaContainerHelper.sendStatistikk(
+                overordnetEnhet = overordnetEnhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode,
+                underenhet = underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode,
+            )
+
+            altinnTilgangerContainerHelper.leggTilRettigheter(
+                underenhet = underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode,
+                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
+                altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
+            )
+
+            val aggregertStatistikkDto = TestContainerHelper.hentAggregertStatistikk(
+                orgnr = underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode.orgnr,
+                config = withToken(),
+            )
+
+            val bransje = underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode.bransje()!!
+
+            val landStatistikk = aggregertStatistikkDto.prosentSiste4KvartalerTotalt
+                .firstOrNull { it.statistikkategori == LAND }
+            landStatistikk.shouldNotBeNull()
+            aggregertStatistikkDto.prosentSiste4KvartalerTotalt.firstOrNull { it.statistikkategori == NÆRING }
+                .shouldBeNull()
+            val bransjeStatistikk =
+                aggregertStatistikkDto.prosentSiste4KvartalerTotalt.firstOrNull { it.statistikkategori == BRANSJE }
+            bransjeStatistikk.shouldNotBeNull()
+            bransjeStatistikk.label shouldBe bransje.navn
+
+            val virksomhetStatistikk = aggregertStatistikkDto.prosentSiste4KvartalerTotalt
+                .firstOrNull { it.statistikkategori == VIRKSOMHET }
+            virksomhetStatistikk.shouldNotBeNull()
+            virksomhetStatistikk.label shouldBe underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode.navn
+
+            val kvartalsvisStatistikkDto = TestContainerHelper.hentKvartalsvisStatistikk(
+                orgnr = underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode.orgnr,
+                config = withToken(),
+            )
+
+            kvartalsvisStatistikkDto.shouldNotBeNull()
+            val actualStatistikkForSektor =
+                kvartalsvisStatistikkDto.firstOrNull { it.type == SEKTOR.name }
+
+            actualStatistikkForSektor.shouldNotBeNull()
+            actualStatistikkForSektor.label shouldBe INGEN_SEKTOR_LABEL
+            actualStatistikkForSektor.kvartalsvisSykefraværsprosent shouldBe emptyList()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/SykefraværsstatistikkApiEndepunkterTest.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/SykefraværsstatistikkApiEndepunkterTest.kt
@@ -82,7 +82,7 @@ class SykefraværsstatistikkApiEndepunkterTest {
         // "tapteDagsverkTotalt": og "muligeDagsverkTotalt"
         runBlocking {
             kafkaContainerHelper.sendLandsstatistikk()
-            kafkaContainerHelper.sendSektorstatistikk(overordnetEnhetMedTilhørighetUtenBransje.sektor)
+            kafkaContainerHelper.sendSektorstatistikk(overordnetEnhetMedTilhørighetUtenBransje.sektor!!)
             kafkaContainerHelper.sendNæringsstatistikk(næring = underenhetMedTilhørighetUtenBransje.næringskode.næring)
             kafkaContainerHelper.sendEnkelVirksomhetsstatistikk(
                 virksomhet = underenhetMedTilhørighetUtenBransje,
@@ -124,7 +124,7 @@ class SykefraværsstatistikkApiEndepunkterTest {
             kafkaContainerHelper.sendSektorstatistikk(
                 startÅr = 2023,
                 sluttÅr = 2024,
-                sektor = overordnetEnhetMedTilhørighetUtenBransje.sektor,
+                sektor = overordnetEnhetMedTilhørighetUtenBransje.sektor!!,
             )
             kafkaContainerHelper.sendNæringsstatistikk(
                 startÅr = 2023,
@@ -161,7 +161,7 @@ class SykefraværsstatistikkApiEndepunkterTest {
     fun `Kvartalsvis statistikk skal være maskert i response`() {
         runBlocking {
             kafkaContainerHelper.sendLandsstatistikk()
-            kafkaContainerHelper.sendSektorstatistikk(overordnetEnhetMedTilhørighetUtenBransje.sektor)
+            kafkaContainerHelper.sendSektorstatistikk(overordnetEnhetMedTilhørighetUtenBransje.sektor!!)
             kafkaContainerHelper.sendNæringsstatistikk(næring = underenhetMedTilhørighetUtenBransje.næringskode.næring)
             kafkaContainerHelper.sendEnkelVirksomhetsstatistikk(
                 virksomhet = underenhetMedTilhørighetUtenBransje,
@@ -210,7 +210,7 @@ class SykefraværsstatistikkApiEndepunkterTest {
                 )
             }
             kafkaContainerHelper.sendLandsstatistikk()
-            kafkaContainerHelper.sendSektorstatistikk(overordnetEnhetUtenStatistikk.sektor)
+            kafkaContainerHelper.sendSektorstatistikk(overordnetEnhetUtenStatistikk.sektor!!)
 
             val bransje = enUnderenhetUtenStatistikk.bransje()
             if (bransje != null) {
@@ -267,7 +267,7 @@ class SykefraværsstatistikkApiEndepunkterTest {
 
             val sektorStatistikk = kvartalsvisStatistikk.firstOrNull { it.type == SEKTOR.name }
             sektorStatistikk.shouldNotBeNull()
-            sektorStatistikk.label shouldBe overordnetEnhetMedTilhørighetUtenBransje2.sektor.beskrivelse
+            sektorStatistikk.label shouldBe overordnetEnhetMedTilhørighetUtenBransje2.sektor?.beskrivelse
             sektorStatistikk.kvartalsvisSykefraværsprosent.size shouldBe 20 // Skal være 5 år
             sektorStatistikk.kvartalsvisSykefraværsprosent.first().prosent bigDecimalShouldBe 6.3
             sektorStatistikk.kvartalsvisSykefraværsprosent.first().tapteDagsverk bigDecimalShouldBe 1275292.330000
@@ -386,7 +386,7 @@ class SykefraværsstatistikkApiEndepunkterTest {
 
             val sektorStatistikk = kvartalsvisStatistikk.firstOrNull { it.type == SEKTOR.name }
             sektorStatistikk.shouldNotBeNull()
-            sektorStatistikk.label shouldBe overordnetEnhetMedEnkelrettighetUtenBransje.sektor.beskrivelse
+            sektorStatistikk.label shouldBe overordnetEnhetMedEnkelrettighetUtenBransje.sektor?.beskrivelse
             sektorStatistikk.kvartalsvisSykefraværsprosent.size shouldBe 20 // Skal være 5 år
             sektorStatistikk.kvartalsvisSykefraværsprosent.first().prosent bigDecimalShouldBe 6.3
             sektorStatistikk.kvartalsvisSykefraværsprosent.first().tapteDagsverk bigDecimalShouldBe 1275292.330000
@@ -446,7 +446,7 @@ class SykefraværsstatistikkApiEndepunkterTest {
 
             val sektorStatistikk = kvartalsvisStatistikk.firstOrNull { it.type == SEKTOR.name }
             sektorStatistikk.shouldNotBeNull()
-            sektorStatistikk.label shouldBe overordnetEnhetMedEnkelrettighetBransjeBarnehage.sektor.beskrivelse
+            sektorStatistikk.label shouldBe overordnetEnhetMedEnkelrettighetBransjeBarnehage.sektor?.beskrivelse
             sektorStatistikk.kvartalsvisSykefraværsprosent.size shouldBe 20 // Skal være 5 år
             sektorStatistikk.kvartalsvisSykefraværsprosent.first().prosent bigDecimalShouldBe 6.3
             sektorStatistikk.kvartalsvisSykefraværsprosent.first().tapteDagsverk bigDecimalShouldBe 1275292.330000

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/helper/KafkaContainerHelper.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/helper/KafkaContainerHelper.kt
@@ -202,7 +202,7 @@ class KafkaContainerHelper(
     ) {
         sendLandsstatistikk()
 
-        sendSektorstatistikk(overordnetEnhet.sektor)
+        sendSektorstatistikk(overordnetEnhet.sektor!!)
 
         underenhet.bransje()?.let { bransje -> sendBransjestatistikk(bransje = bransje) }
             ?: sendNæringsstatistikk(næring = underenhet.næringskode.næring)

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/helper/TestdataHelper.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/helper/TestdataHelper.kt
@@ -255,7 +255,7 @@ class TestdataHelper {
             overordnetEnhetOrgnr = overordnetEnhetUtenTilgang.orgnr,
         )
 
-        val overordnetEnhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode =
+        val overordnetEnhetIBransjeByggUtenInstitusjonellSektorKode =
             OverordnetEnhet(
                 orgnr = "100000019",
                 navn = "Overordnet Enhet Med Tilhørighet Bransje Bygg uten sektor kode",
@@ -270,7 +270,7 @@ class TestdataHelper {
                 ).tilDomene(),
             )
 
-        val underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode =
+        val underenhetIBransjeByggUtenInstitusjonellSektorKode =
             Underenhet.Næringsdrivende(
                 orgnr = "100000020",
                 navn = "Underenhet Med Tilhørighet Bransje Bygg uten sektor kode",

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/helper/TestdataHelper.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/helper/TestdataHelper.kt
@@ -255,6 +255,33 @@ class TestdataHelper {
             overordnetEnhetOrgnr = overordnetEnhetUtenTilgang.orgnr,
         )
 
+        val overordnetEnhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode =
+            OverordnetEnhet(
+                orgnr = "100000019",
+                navn = "Overordnet Enhet Med Tilhørighet Bransje Bygg uten sektor kode",
+                antallAnsatte = 150,
+                næringskode = BrregNæringskodeDto(
+                    kode = "41.200",
+                    beskrivelse = "Oppføring av bygninger",
+                ).tilDomene(),
+                sektor = BrregInstitusjonellSektorkodeDto(
+                    kode = "2100",
+                    beskrivelse = "Private aksjeselskaper mv.",
+                ).tilDomene(),
+            )
+
+        val underenhetMedTilhørighetBransjeByggUtenInstitusjonellSektorKode =
+            Underenhet.Næringsdrivende(
+                orgnr = "100000020",
+                navn = "Underenhet Med Tilhørighet Bransje Bygg uten sektor kode",
+                antallAnsatte = 150,
+                næringskode = BrregNæringskodeDto(
+                    kode = "41.200",
+                    beskrivelse = "Oppføring av bygninger",
+                ).tilDomene(),
+                overordnetEnhetOrgnr = overordnetEnhetMedTilhørighetBransjeBygg.orgnr,
+            )
+
         @OptIn(ExperimentalSerializationApi::class)
         inline fun <reified T> prettyPrint(statistikk: T) {
             val prettyJson = Json {

--- a/src/test/resources/__files/brreg/tilgang/enhet-bygg-uten-sektor.json
+++ b/src/test/resources/__files/brreg/tilgang/enhet-bygg-uten-sektor.json
@@ -1,0 +1,61 @@
+{
+  "organisasjonsnummer": "100000019",
+  "navn": "Overordnet Enhet Med Tilhørighet Bransje Bygg uten sektor",
+  "organisasjonsform": {
+    "kode": "AS",
+    "beskrivelse": "Aksjeselskap",
+    "_links": {
+      "self": {
+        "href": "https://data.brreg.no/enhetsregisteret/api/organisasjonsformer/AS"
+      }
+    }
+  },
+  "registreringsdatoEnhetsregisteret": "1992-09-18",
+  "registrertIMvaregisteret": true,
+  "naeringskode1": {
+    "kode": "41.200",
+    "beskrivelse": "Oppføring av bygninger"
+  },
+  "antallAnsatte": 150,
+  "harRegistrertAntallAnsatte": true,
+  "registreringsdatoMerverdiavgiftsregisteret": "1992-09-18",
+  "registreringsdatoMerverdiavgiftsregisteretEnhetsregisteret": "1992-09-18",
+  "registreringsdatoAntallAnsatteEnhetsregisteret": "1992-09-18",
+  "registreringsdatoAntallAnsatteNAVAaregisteret": "1992-09-18",
+  "epostadresse": "epost@epost.no",
+  "mobil": "10 20 30 40",
+  "forretningsadresse": {
+    "land": "Norge",
+    "landkode": "NO",
+    "postnummer": "",
+    "poststed": "",
+    "adresse": [
+      ""
+    ],
+    "kommune": "BERGEN",
+    "kommunenummer": "4601"
+  },
+  "stiftelsesdato": "1992-09-18",
+  "registrertIForetaksregisteret": true,
+  "registrertIStiftelsesregisteret": false,
+  "registrertIFrivillighetsregisteret": false,
+  "sisteInnsendteAarsregnskap": "1992",
+  "konkurs": false,
+  "underAvvikling": false,
+  "underTvangsavviklingEllerTvangsopplosning": false,
+  "maalform": "Bokmål",
+  "vedtektsdato": "1992-09-18",
+  "vedtektsfestetFormaal": [
+    ""
+  ],
+  "aktivitet": [
+    ""
+  ],
+  "registreringsdatoForetaksregisteret": "1992-09-18",
+  "registrertIPartiregisteret": false,
+  "_links": {
+    "self": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/100000019"
+    }
+  }
+}

--- a/src/test/resources/__files/brreg/tilgang/enkelrettighet/underenhet-bygg-uten-sektor.json
+++ b/src/test/resources/__files/brreg/tilgang/enkelrettighet/underenhet-bygg-uten-sektor.json
@@ -1,0 +1,53 @@
+{
+  "organisasjonsnummer": "100000020",
+  "navn": "Underenhet Med Tilhørighet Bransje Bygg uten sektor kode",
+  "organisasjonsform": {
+    "kode": "BEDR",
+    "beskrivelse": "Underenhet til Bygg Uten Sektor",
+    "_links": {
+      "self": {
+        "href": "https://data.brreg.no/enhetsregisteret/api/organisasjonsformer/BEDR"
+      }
+    }
+  },
+  "postadresse": {
+    "land": "Norge",
+    "landkode": "NO",
+    "postnummer": "",
+    "poststed": "",
+    "adresse": [],
+    "kommune": "BERGEN",
+    "kommunenummer": "4601"
+  },
+  "registreringsdatoEnhetsregisteret": "1992-09-18",
+  "registrertIMvaregisteret": false,
+  "naeringskode1": {
+    "kode": "41.200",
+    "beskrivelse": "Oppføring av bygninger"
+  },
+  "antallAnsatte": 100,
+  "harRegistrertAntallAnsatte": true,
+  "overordnetEnhet": "100000019",
+  "registreringsdatoAntallAnsatteEnhetsregisteret": "1992-09-18",
+  "registreringsdatoAntallAnsatteNAVAaregisteret": "1992-09-18",
+  "datoEierskifte": "1992-09-18",
+  "beliggenhetsadresse": {
+    "land": "Norge",
+    "landkode": "NO",
+    "postnummer": "",
+    "poststed": "",
+    "adresse": [
+      ""
+    ],
+    "kommune": "BERGEN",
+    "kommunenummer": "4601"
+  },
+  "_links": {
+    "self": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/underenheter/100000020"
+    },
+    "overordnetEnhet": {
+      "href": "https://data.brreg.no/enhetsregisteret/api/enheter/100000019"
+    }
+  }
+}

--- a/src/test/resources/mappings/brreg/tilgang/enhet-bygg-uten-sektor.json
+++ b/src/test/resources/mappings/brreg/tilgang/enhet-bygg-uten-sektor.json
@@ -1,0 +1,15 @@
+{
+  "request" : {
+    "urlPathPattern" : "/enhetsregisteret/api/enheter/100000019",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "bodyFileName": "brreg/tilgang/enhet-bygg-uten-sektor.json",
+    "headers" : {
+      "Content-Type" : "application/json"
+    }
+  }
+}
+
+

--- a/src/test/resources/mappings/brreg/tilgang/enkelrettighet/underenhet-bygg-uten-sektor.json
+++ b/src/test/resources/mappings/brreg/tilgang/enkelrettighet/underenhet-bygg-uten-sektor.json
@@ -1,0 +1,13 @@
+{
+  "request": {
+    "urlPathPattern": "/enhetsregisteret/api/underenheter/100000020",
+    "method": "GET"
+  },
+  "response": {
+    "status": 200,
+    "bodyFileName": "brreg/tilgang/enkelrettighet/underenhet-bygg-uten-sektor.json",
+    "headers": {
+      "Content-Type": "application/json"
+    }
+  }
+}


### PR DESCRIPTION
Fikser en feil som oppstår nå vi ikke får hentet institusjonell sektor kode i overordnet enhet fordi informasjon er ikke tilgjengelig i Brreg. Uten denne koden vil applikasjon returnere en 500 og logge en melding i error. 
Med endringen som kommer i denne PR returnerer vi 200 OK, men ingen statistikk for Sektor. Det som kan utledes blir returnert (land, bransje/næring, virksomhet, ...osv) 
Label til statistikk for Sektor i /kvartalsvis endepunkt blir da "Ingen sektor" og lista av kvartalsvis statistikk for sektor blir tom. 
Dette gjelder veldig få virksomheter i utgangspunktet. 