### PR TITLE
Erstatte testcontainers.mockserver med software.xdev.mockserver

### DIFF
--- a/.github/workflows/build-and-deploy.yaml
+++ b/.github/workflows/build-and-deploy.yaml
@@ -65,7 +65,7 @@ jobs:
       id-token: write
     name: Deploy app to dev
     needs: build
-    if: github.ref == 'refs/heads/overordnet-enhet-uten-sektor'
+    if: github.ref == 'refs/heads/erstatte-mockserver-med-sin-nyere-fork'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,8 +67,8 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers:$testcontainersVersion")
     testImplementation("org.testcontainers:kafka:$testcontainersVersion")
     testImplementation("org.testcontainers:postgresql:$testcontainersVersion")
-    testImplementation("org.testcontainers:mockserver:$testcontainersVersion")
-    testImplementation("org.mock-server:mockserver-client-java:$testMockServerVersion")
+    testImplementation("software.xdev.mockserver:testcontainers:1.0.14")
+    testImplementation("software.xdev.mockserver:client:1.0.14")
 
     testImplementation("io.aiven:testcontainers-fake-gcs-server:0.2.0")
     testImplementation("org.wiremock:wiremock-standalone:$wiremockStandaloneVersion")
@@ -88,30 +88,6 @@ dependencies {
                 require("4.1.119.Final")
             }
             because("From Ktor version: 2.3.5 -> io.netty:netty-codec-http2 vulnerable to HTTP/2 Rapid Reset Attack")
-        }
-        testImplementation("com.google.guava:guava") {
-            version {
-                require("33.4.0-jre")
-            }
-            because("Mockserver har sårbar guava versjon")
-        }
-        testImplementation("org.bouncycastle:bcprov-jdk18on") {
-            version {
-                require("1.80")
-            }
-            because("bcprov-jdk18on in Mockserver har sårbar versjon")
-        }
-        testImplementation("org.bouncycastle:bcpkix-jdk18on") {
-            version {
-                require("1.80")
-            }
-            because("bcpkix-jdk18on in Mockserver har sårbar versjon")
-        }
-        testImplementation("org.xmlunit:xmlunit-core") {
-            version {
-                require("2.10.0")
-            }
-            because("xmlunit-core in Mockserver har sårbar versjon")
         }
         testImplementation("org.apache.commons:commons-compress") {
             version {

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/helper/AltinnTilgangerContainerHelper.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/helper/AltinnTilgangerContainerHelper.kt
@@ -1,59 +1,88 @@
 package no.nav.pia.sykefravarsstatistikk.helper
 
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonIgnoreUnknownKeys
 import no.nav.pia.sykefravarsstatistikk.domene.OverordnetEnhet
 import no.nav.pia.sykefravarsstatistikk.domene.Underenhet
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.log
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.overordnetEnhetUtenTilgang
-import org.mockserver.client.MockServerClient
-import org.mockserver.model.HttpRequest.request
-import org.mockserver.model.HttpResponse.response
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.Network
 import org.testcontainers.containers.output.Slf4jLogConsumer
 import org.testcontainers.containers.wait.strategy.Wait
 import org.testcontainers.utility.DockerImageName
+import software.xdev.mockserver.client.MockServerClient
+import software.xdev.mockserver.model.Format
+import software.xdev.mockserver.model.HttpRequest.request
+import software.xdev.mockserver.model.HttpResponse.response
+import software.xdev.testcontainers.mockserver.containers.MockServerContainer
+import software.xdev.testcontainers.mockserver.containers.MockServerContainer.PORT
 
 class AltinnTilgangerContainerHelper(
     network: Network = Network.newNetwork(),
     logger: Logger = LoggerFactory.getLogger(AltinnTilgangerContainerHelper::class.java),
 ) {
     private val networkAlias = "mockAltinnTilgangerContainer"
-    private val port = 7070
+    private val port =
+        PORT // mockserver default port er 1080 som MockServerContainer() eksponerer selv med "this.addExposedPort(1080);"
+    private var mockServerClient: MockServerClient? = null
 
-    val dockerImageName = DockerImageName.parse("mockserver/mockserver")
-    val altinnTilgangerContainer = GenericContainer(dockerImageName)
-        .withNetwork(network)
-        .withNetworkAliases(networkAlias)
-        .withExposedPorts(port)
-        .withLogConsumer(Slf4jLogConsumer(logger).withPrefix(networkAlias).withSeparateOutputStreams())
-        .withEnv(
-            mapOf(
-                "MOCKSERVER_LIVENESS_HTTP_GET_PATH" to "/isRunning",
-                "SERVER_PORT" to "7070",
-                "TZ" to "Europe/Oslo",
-            ),
-        )
-        .waitingFor(Wait.forHttp("/isRunning").forStatusCode(200))
-        .apply {
-            start()
-        }.also {
-            logger.info("Startet (mock) altinnTilganger container for network '$network' og port '$port'")
-        }
+    val dockerImageName = DockerImageName.parse("xdevsoftware/mockserver:1.0.14")
+    val altinnTilgangerContainer =
+        MockServerContainer(dockerImageName)
+            .withNetwork(network)
+            .withNetworkAliases(networkAlias)
+            .withLogConsumer(Slf4jLogConsumer(logger).withPrefix(networkAlias).withSeparateOutputStreams())
+            .withEnv(
+                mapOf(
+                    "MOCKSERVER_LIVENESS_HTTP_GET_PATH" to "/isRunning",
+                    "SERVER_PORT" to "$port",
+                    "TZ" to "Europe/Oslo",
+                ),
+            )
+            .waitingFor(Wait.forHttp("/isRunning").forStatusCode(200)).apply {
+                start()
+            }.also {
+                logger.info("Startet (mock) altinnTilganger container for network '$network' og port '$port'")
+            }
 
     fun envVars() =
         mapOf(
             "ALTINN_TILGANGER_PROXY_URL" to "http://$networkAlias:$port",
         )
 
+    private fun getMockServerClient(): MockServerClient {
+        if (mockServerClient == null) {
+            log.info(
+                "Oppretter MockServerClient med host '${altinnTilgangerContainer.host}' og port '${
+                    altinnTilgangerContainer.getMappedPort(port)
+                }'",
+            )
+            mockServerClient = MockServerClient(
+                altinnTilgangerContainer.host,
+                altinnTilgangerContainer.getMappedPort(port),
+            )
+        }
+        return mockServerClient!!
+    }
+
     internal fun slettAlleRettigheter() {
-        val client = MockServerClient(
-            altinnTilgangerContainer.host,
-            altinnTilgangerContainer.getMappedPort(7070),
-        )
-        client.reset()
+        val client = getMockServerClient()
+
+        runBlocking {
+            val activeExpectations: String = client.retrieveActiveExpectations(
+                request().withPath("/altinn-tilganger").withMethod("POST"), Format.JSON
+            )
+            val expectations: List<Expectation> = Json.decodeFromString(activeExpectations)
+            expectations.forEach { expectation ->
+                client.clear(expectation.id)
+            }
+            log.info("Funnet og slettet '${expectations.size}' aktive expectations")
+        }
     }
 
     internal fun leggTilRettigheter(
@@ -62,17 +91,8 @@ class AltinnTilgangerContainerHelper(
         altinn2Rettighet: String = "",
         altinn3Rettighet: String = "nav-ia-sykefravarsstatistikk-IKKE-SATT-OPP-ENDA",
     ) {
-        log.debug(
-            "Oppretter MockServerClient med host '${altinnTilgangerContainer.host}' og port '${
-                altinnTilgangerContainer.getMappedPort(
-                    7070,
-                )
-            }'. Og legger til rettighet '$altinn2Rettighet' for underenhet '${underenhet.orgnr}'",
-        )
-        val client = MockServerClient(
-            altinnTilgangerContainer.host,
-            altinnTilgangerContainer.getMappedPort(7070),
-        )
+        log.info("Legger til rettigheter [altinn2: '$altinn2Rettighet' og altinn3: '$altinn3Rettighet'] for underenhet '${underenhet.orgnr}'")
+        val client = getMockServerClient()
         runBlocking {
             client.`when`(
                 request()
@@ -126,4 +146,11 @@ class AltinnTilgangerContainerHelper(
             )
         }
     }
+
+    @OptIn(ExperimentalSerializationApi::class)
+    @Serializable
+    @JsonIgnoreUnknownKeys
+    internal data class Expectation(
+        val id: String,
+    )
 }


### PR DESCRIPTION
software.xdev.mockserver (for testcontainers) er en lightweight versjon (fork) av den opprinnelige mockserver (ikke patchet i de siste to årene)
xdev.mockserver fungerer (nesten) likt den gamle mockserver

En liten endring i API-et:
 - method-en MockServerClient.reset() sletter ikke lenger alle eksisterende expectations
 - den er erstattet med `client.retrieveActiveExpectations()` + `client.clear(expectation.id)` for alle expectations funnet

Slettet noen constraints på transitive dependencies som ikke er sårbare lenger i den nyere xdev.mockserver