### PR TITLE
Slutt a verifisere altinn2 tilgang

### DIFF
--- a/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/api/aggregering/AggregertStatistikkService.kt
+++ b/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/api/aggregering/AggregertStatistikkService.kt
@@ -31,7 +31,7 @@ class AggregertStatistikkService(
 
         val aggregeringskategorier = buildList {
             add(Aggregeringskategorier.Land)
-            if (tilganger.harEnkeltTilgang) {
+            if (tilganger.harEnkeltrettighetUnderenhet) {
                 add(Aggregeringskategorier.Virksomhet(virksomhet))
             }
 

--- a/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/api/auth/AltinnOrganisajonerBrukerenHarTilgangTilPlugin.kt
+++ b/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/api/auth/AltinnOrganisajonerBrukerenHarTilgangTilPlugin.kt
@@ -25,7 +25,6 @@ fun AltinnOrganisajonerBrukerenHarTilgangTilPlugin(altinnTilgangerService: Altin
                     altinnTilganger.altinnOrganisasjonerVedkommendeHarTilgangTil()
                 val altinnOrganisasjonerVedkommendeHarEnkeltrettighetTil =
                     altinnTilganger.altinnOrganisasjonerVedkommendeHarEnkeltrettighetTil(
-                        enkeltrettighetIAltinn2 = Systemmiljø.altinn2EnkeltrettighetKode,
                         enkeltrettighetIAltinn3 = Systemmiljø.altinn3RessursId,
                     )
 

--- a/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/api/auth/AltinnTilgangerService.kt
+++ b/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/api/auth/AltinnTilgangerService.kt
@@ -18,7 +18,6 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import no.nav.pia.sykefravarsstatistikk.Metrics
 import no.nav.pia.sykefravarsstatistikk.Systemmiljø.altinnTilgangerProxyUrl
 import no.nav.pia.sykefravarsstatistikk.Systemmiljø.cluster
 import no.nav.pia.sykefravarsstatistikk.domene.AltinnOrganisasjon

--- a/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/api/auth/VerifisertEnkelrettighetForOrgnrPlugin.kt
+++ b/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/api/auth/VerifisertEnkelrettighetForOrgnrPlugin.kt
@@ -94,8 +94,8 @@ fun VerifisertEnkelrettighetForOrgnrPlugin(enhetsregisteretService: Enhetsregist
                     call.attributes.put(
                         VerifiserteTilgangerKey,
                         VerifiserteTilganger(
-                            harEnkeltTilgang = harEnkeltRettighetTilUnderenhet,
-                            harEnkeltTilgangOverordnetEnhet = harEnkeltRettighetTilOverordnetEnhet,
+                            harEnkeltrettighetUnderenhet = harEnkeltRettighetTilUnderenhet,
+                            harEnkeltrettighetOverordnetEnhet = harEnkeltRettighetTilOverordnetEnhet,
                         ),
                     )
                     call.attributes.put(UnderenhetKey, underenhet)
@@ -127,6 +127,6 @@ val UnderenhetKey = AttributeKey<Underenhet>("Underenhet")
 val OverordnetEnhetKey = AttributeKey<OverordnetEnhet>("OverordnetEnhet")
 
 data class VerifiserteTilganger(
-    val harEnkeltTilgang: Boolean,
-    val harEnkeltTilgangOverordnetEnhet: Boolean,
+    val harEnkeltrettighetUnderenhet: Boolean,
+    val harEnkeltrettighetOverordnetEnhet: Boolean,
 )

--- a/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/persistering/KvartalsvisSykefraværshistorikkService.kt
+++ b/src/main/kotlin/no/nav/pia/sykefravarsstatistikk/persistering/KvartalsvisSykefraværshistorikkService.kt
@@ -108,7 +108,7 @@ class KvartalsvisSykefraværshistorikkService(
         underenhet: Underenhet.Næringsdrivende,
         tilganger: VerifiserteTilganger,
     ): Either<Feil, List<MaskertKvartalsvisSykefraværshistorikkDto>> {
-        if (!tilganger.harEnkeltTilgang) {
+        if (!tilganger.harEnkeltrettighetUnderenhet) {
             return Feil(
                 feilmelding = "{\"message\":\"You don't have access to this resource\"}",
                 httpStatusCode = HttpStatusCode.Forbidden,
@@ -212,7 +212,7 @@ class KvartalsvisSykefraværshistorikkService(
             ),
         )
 
-        val umaskertVirksomhetsstatistikk = if (tilganger.harEnkeltTilgangOverordnetEnhet) {
+        val umaskertVirksomhetsstatistikk = if (tilganger.harEnkeltrettighetOverordnetEnhet) {
             hentSykefraværsstatistikkVirksomhet(
                 virksomhet = overordnetEnhet,
                 førsteÅrstalOgKvartal = førsteKvartal,

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/EdgeCasesSykefraværsstatistikkApiEndepunkterTest.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/EdgeCasesSykefraværsstatistikkApiEndepunkterTest.kt
@@ -16,7 +16,6 @@ import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.altinnTilgangerContainerHelper
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.kafkaContainerHelper
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.postgresContainerHelper
-import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.overordnetEnhetIBransjeByggUtenInstitusjonellSektorKode
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.overordnetEnhetMedUnderenhetUtenNæringskode
@@ -51,7 +50,6 @@ class EdgeCasesSykefraværsstatistikkApiEndepunkterTest {
             )
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhetIBransjeByggUtenInstitusjonellSektorKode.somNæringsdrivende(),
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
 
@@ -101,7 +99,6 @@ class EdgeCasesSykefraværsstatistikkApiEndepunkterTest {
             )
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhetUtenNæringskode.somIkkeNæringsdrivende(),
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
 

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/OrganisasjonerEndepunktTest.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/OrganisasjonerEndepunktTest.kt
@@ -10,7 +10,6 @@ import no.nav.pia.sykefravarsstatistikk.domene.OverordnetEnhet
 import no.nav.pia.sykefravarsstatistikk.domene.Underenhet
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.altinnTilgangerContainerHelper
-import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.overordnetEnhetINæringUtvinningAvRåoljeOgGass
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.somNæringsdrivende
@@ -36,7 +35,7 @@ class OrganisasjonerEndepunktTest {
         altinnTilgangerContainerHelper.leggTilRettigheter(
             overordnetEnhet = overordnetEnhet,
             underenhet = underenhet,
-            altinn2Rettighet = "En annen enkeltrettighet",
+            altinn3Rettighet = "En annen enkeltrettighet",
         )
 
         runBlocking {
@@ -70,7 +69,7 @@ class OrganisasjonerEndepunktTest {
         altinnTilgangerContainerHelper.leggTilRettigheter(
             overordnetEnhet = overordnetEnhet,
             underenhet = underenhet,
-            altinn2Rettighet = "En annen enkeltrettighet",
+            altinn3Rettighet = "En annen enkeltrettighet",
         )
 
         runBlocking {
@@ -92,7 +91,7 @@ class OrganisasjonerEndepunktTest {
         altinnTilgangerContainerHelper.leggTilRettigheter(
             overordnetEnhet = overordnetEnhet,
             underenhet = underenhet,
-            altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
+            altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
         )
 
         runBlocking {
@@ -121,7 +120,6 @@ class OrganisasjonerEndepunktTest {
         altinnTilgangerContainerHelper.leggTilRettigheter(
             overordnetEnhet = overordnetEnhet,
             underenhet = underenhet,
-            altinn2Rettighet = "En annen enkeltrettighet",
             altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
         )
 

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/SykefraværsstatistikkApiEndepunkterIntegrasjonsTest.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/SykefraværsstatistikkApiEndepunkterIntegrasjonsTest.kt
@@ -21,7 +21,6 @@ import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.altinnTilgangerContainerHelper
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.kafkaContainerHelper
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.postgresContainerHelper
-import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.overordnetEnhetIBransjeSykehjem
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.somNæringsdrivende
@@ -57,7 +56,6 @@ class SykefraværsstatistikkApiEndepunkterIntegrasjonsTest {
         runBlocking {
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhet,
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
             lagLandStatistikkTestCase()
@@ -118,7 +116,6 @@ class SykefraværsstatistikkApiEndepunkterIntegrasjonsTest {
         runBlocking {
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhet,
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
             val expectedStatistikkLand = lagLandStatistikkTestCase()

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/SykefraværsstatistikkApiEndepunkterTest.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/SykefraværsstatistikkApiEndepunkterTest.kt
@@ -25,7 +25,6 @@ import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.altinnTilgangerContainerHelper
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.kafkaContainerHelper
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.postgresContainerHelper
-import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.overordnetEnhetIBransjeAnlegg
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.overordnetEnhetIBransjeBarnehage
@@ -66,7 +65,6 @@ class SykefraværsstatistikkApiEndepunkterTest {
             )
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhetINæringUtleieAvEiendom.somNæringsdrivende(),
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
 
@@ -96,7 +94,6 @@ class SykefraværsstatistikkApiEndepunkterTest {
             )
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhetINæringUtleieAvEiendom.somNæringsdrivende(),
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
 
@@ -138,7 +135,6 @@ class SykefraværsstatistikkApiEndepunkterTest {
             )
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhetINæringUtleieAvEiendom.somNæringsdrivende(),
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
 
@@ -177,7 +173,6 @@ class SykefraværsstatistikkApiEndepunkterTest {
             )
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhetINæringUtleieAvEiendom.somNæringsdrivende(),
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
 
@@ -205,7 +200,6 @@ class SykefraværsstatistikkApiEndepunkterTest {
         runBlocking {
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhetIBransjeAnlegg.somNæringsdrivende(),
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
 
@@ -255,7 +249,6 @@ class SykefraværsstatistikkApiEndepunkterTest {
             )
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhetINæringProduksjonAvMatfisk.somNæringsdrivende(),
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
 
@@ -315,7 +308,6 @@ class SykefraværsstatistikkApiEndepunkterTest {
             )
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhetIBransjeSykehus.somNæringsdrivende(),
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
 
@@ -374,7 +366,6 @@ class SykefraværsstatistikkApiEndepunkterTest {
             )
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhetINæringSkogskjøtsel.somNæringsdrivende(),
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
 
@@ -435,7 +426,6 @@ class SykefraværsstatistikkApiEndepunkterTest {
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 overordnetEnhet = overordnetEnhetIBransjeBarnehage.somOverordnetEnhet(),
                 underenhet = underenhetIBransjeBarnehage.somNæringsdrivende(),
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
 
@@ -498,7 +488,6 @@ class SykefraværsstatistikkApiEndepunkterTest {
             )
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhetIBransjeBarnehage.somNæringsdrivende(),
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
                 altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
 

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/TilgangTilSykefraværsstatistikkApiEndepunkterTest.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/TilgangTilSykefraværsstatistikkApiEndepunkterTest.kt
@@ -97,7 +97,7 @@ class TilgangTilSykefraværsstatistikkApiEndepunkterTest {
         runBlocking {
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhetIBransjeBarnehage.somNæringsdrivende(),
-                altinn2Rettighet = "enkeltrettighet_som_ikke_er_sykefraværsstatistikk",
+                altinn3Rettighet = "enkeltrettighet_som_ikke_er_sykefraværsstatistikk",
             )
             kafkaContainerHelper.sendStatistikk(
                 underenhet = underenhetIBransjeBarnehage.somNæringsdrivende(),

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/auditlog/AuditlogTest.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/auditlog/AuditlogTest.kt
@@ -9,7 +9,7 @@ import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.app
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.kafkaContainerHelper
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.shouldContainLog
 import no.nav.pia.sykefravarsstatistikk.helper.TestContainerHelper.Companion.shouldNotContainLog
-import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2
+import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.overordnetEnhetINæringUtleieAvEiendom
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.somNæringsdrivende
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.somOverordnetEnhet
@@ -36,7 +36,7 @@ class AuditlogTest {
             )
             altinnTilgangerContainerHelper.leggTilRettigheter(
                 underenhet = underenhetINæringUtleieAvEiendom.somNæringsdrivende(),
-                altinn2Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
+                altinn3Rettighet = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
             )
 
             TestContainerHelper.hentKvartalsvisStatistikk(

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/auth/AltinnTilgangerServiceUnitTest.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/auth/AltinnTilgangerServiceUnitTest.kt
@@ -2,15 +2,16 @@ package no.nav.pia.sykefravarsstatistikk.api.auth
 
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
+import kotlinx.serialization.json.Json
 import no.nav.pia.sykefravarsstatistikk.api.auth.AltinnTilgangerService.AltinnTilgang
 import no.nav.pia.sykefravarsstatistikk.api.auth.AltinnTilgangerService.AltinnTilganger
-import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2
 import no.nav.pia.sykefravarsstatistikk.helper.TestdataHelper.Companion.ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3
 import no.nav.pia.sykefravarsstatistikk.api.auth.AltinnTilgangerService.Companion.altinnOrganisasjonerVedkommendeHarEnkeltrettighetTil
 import no.nav.pia.sykefravarsstatistikk.api.auth.AltinnTilgangerService.Companion.altinnOrganisasjonerVedkommendeHarTilgangTil
 import no.nav.pia.sykefravarsstatistikk.api.auth.AltinnTilgangerService.Companion.finnOverordnetEnhet
-import no.nav.pia.sykefravarsstatistikk.api.auth.AltinnTilgangerService.Companion.harEnkeltrettighet
+import no.nav.pia.sykefravarsstatistikk.api.auth.AltinnTilgangerService.Companion.harEnkeltrettighetIAltinn3
 import no.nav.pia.sykefravarsstatistikk.api.auth.AltinnTilgangerService.Companion.harTilgangTilOrgnr
+import no.nav.pia.sykefravarsstatistikk.api.auth.AltinnTilgangerTestCase.Companion.jsonResponseFraAltinnTilgangerIDevMiljø
 import no.nav.pia.sykefravarsstatistikk.domene.AltinnOrganisasjon
 import kotlin.test.Test
 
@@ -29,27 +30,25 @@ class AltinnTilgangerServiceUnitTest {
             overordnetEnhet = EnkeltrettigheterTilEnVirksomhet(
                 orgnr = overordnetEnhet,
                 navn = "Overordnet enhet",
-                enkeltrettigheterAltinn2 = emptySet(),
+                enkeltrettigheterAltinn3 = emptySet(),
             ),
             underenheter = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = "989898989",
                     navn = "Ikke den underenheten vi leter etter",
-                    enkeltrettigheterAltinn2 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2),
+                    enkeltrettigheterAltinn3 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3),
                 ),
             ),
         )
 
         altinnTilganger.harTilgangTilOrgnr(underenhet) shouldBe false
         altinnTilganger.harTilgangTilOrgnr(overordnetEnhet) shouldBe true
-        altinnTilganger.harEnkeltrettighet(
+        altinnTilganger.harEnkeltrettighetIAltinn3(
             orgnr = underenhet,
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
             enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
         ) shouldBe false
-        altinnTilganger.harEnkeltrettighet(
+        altinnTilganger.harEnkeltrettighetIAltinn3(
             orgnr = overordnetEnhet,
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
             enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
         ) shouldBe false
     }
@@ -60,27 +59,25 @@ class AltinnTilgangerServiceUnitTest {
             overordnetEnhet = EnkeltrettigheterTilEnVirksomhet(
                 orgnr = overordnetEnhet,
                 navn = "Overordnet enhet",
-                enkeltrettigheterAltinn2 = emptySet(),
+                enkeltrettigheterAltinn3 = emptySet(),
             ),
             underenheter = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhet,
                     navn = "Underenhet",
-                    enkeltrettigheterAltinn2 = emptySet(),
+                    enkeltrettigheterAltinn3 = emptySet(),
                 ),
             ),
         )
 
         altinnTilganger.harTilgangTilOrgnr(underenhet) shouldBe true
         altinnTilganger.harTilgangTilOrgnr(overordnetEnhet) shouldBe true
-        altinnTilganger.harEnkeltrettighet(
+        altinnTilganger.harEnkeltrettighetIAltinn3(
             orgnr = underenhet,
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
             enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
         ) shouldBe false
-        altinnTilganger.harEnkeltrettighet(
+        altinnTilganger.harEnkeltrettighetIAltinn3(
             orgnr = overordnetEnhet,
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
             enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
         ) shouldBe false
     }
@@ -91,13 +88,12 @@ class AltinnTilgangerServiceUnitTest {
             overordnetEnhet = EnkeltrettigheterTilEnVirksomhet(
                 orgnr = overordnetEnhet,
                 navn = "Overordnet enhet",
-                enkeltrettigheterAltinn2 = emptySet(),
+                enkeltrettigheterAltinn3 = emptySet(),
             ),
             underenheter = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhet,
                     navn = "Underenhet",
-                    enkeltrettigheterAltinn2 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2),
                     enkeltrettigheterAltinn3 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3),
                 ),
             ),
@@ -105,14 +101,12 @@ class AltinnTilgangerServiceUnitTest {
 
         altinnTilganger.harTilgangTilOrgnr(underenhet) shouldBe true
         altinnTilganger.harTilgangTilOrgnr(overordnetEnhet) shouldBe true
-        altinnTilganger.harEnkeltrettighet(
+        altinnTilganger.harEnkeltrettighetIAltinn3(
             orgnr = underenhet,
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
             enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
         ) shouldBe true
-        altinnTilganger.harEnkeltrettighet(
+        altinnTilganger.harEnkeltrettighetIAltinn3(
             orgnr = overordnetEnhet,
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
             enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
         ) shouldBe false
     }
@@ -123,13 +117,12 @@ class AltinnTilgangerServiceUnitTest {
             overordnetEnhet = EnkeltrettigheterTilEnVirksomhet(
                 orgnr = overordnetEnhet,
                 navn = "Overordnet enhet",
-                enkeltrettigheterAltinn2 = emptySet(),
+                enkeltrettigheterAltinn3 = emptySet(),
             ),
             underenheter = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhet,
                     navn = "Underenhet",
-                    enkeltrettigheterAltinn2 = emptySet(),
                     enkeltrettigheterAltinn3 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3),
                 ),
             ),
@@ -137,14 +130,12 @@ class AltinnTilgangerServiceUnitTest {
 
         altinnTilganger.harTilgangTilOrgnr(underenhet) shouldBe true
         altinnTilganger.harTilgangTilOrgnr(overordnetEnhet) shouldBe true
-        altinnTilganger.harEnkeltrettighet(
+        altinnTilganger.harEnkeltrettighetIAltinn3(
             orgnr = underenhet,
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
             enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
         ) shouldBe true
-        altinnTilganger.harEnkeltrettighet(
+        altinnTilganger.harEnkeltrettighetIAltinn3(
             orgnr = overordnetEnhet,
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
             enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
         ) shouldBe false
     }
@@ -155,27 +146,25 @@ class AltinnTilgangerServiceUnitTest {
             overordnetEnhet = EnkeltrettigheterTilEnVirksomhet(
                 orgnr = overordnetEnhet,
                 navn = "Overordnet enhet",
-                enkeltrettigheterAltinn2 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2),
+                enkeltrettigheterAltinn3 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3),
             ),
             underenheter = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhet,
                     navn = "Underenhet",
-                    enkeltrettigheterAltinn2 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2),
+                    enkeltrettigheterAltinn3 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3),
                 ),
             ),
         )
 
         altinnTilganger.harTilgangTilOrgnr(underenhet) shouldBe true
         altinnTilganger.harTilgangTilOrgnr(overordnetEnhet) shouldBe true
-        altinnTilganger.harEnkeltrettighet(
+        altinnTilganger.harEnkeltrettighetIAltinn3(
             orgnr = underenhet,
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
             enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
         ) shouldBe true
-        altinnTilganger.harEnkeltrettighet(
+        altinnTilganger.harEnkeltrettighetIAltinn3(
             orgnr = overordnetEnhet,
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
             enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
         ) shouldBe true
     }
@@ -191,53 +180,8 @@ class AltinnTilgangerServiceUnitTest {
 
         altinnTilganger.altinnOrganisasjonerVedkommendeHarTilgangTil() shouldBe emptyList()
         altinnTilganger.altinnOrganisasjonerVedkommendeHarEnkeltrettighetTil(
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
             enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
         ) shouldBe emptyList()
-    }
-
-    @Test
-    fun `listen av AltinnVirksomheter en bruker har tilgang til inneholder riktige virksomheter (bare med Altinn 2)`() {
-        val altinnTilganger = lagAltinnTilganger(
-            overordnetEnhet = EnkeltrettigheterTilEnVirksomhet(
-                orgnr = overordnetEnhet,
-                navn = "Overordnet enhet",
-                enkeltrettigheterAltinn2 = emptySet(),
-            ),
-            underenheter = listOf(
-                EnkeltrettigheterTilEnVirksomhet(
-                    orgnr = underenhet,
-                    navn = "Underenhet",
-                    enkeltrettigheterAltinn2 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2),
-                ),
-            ),
-        )
-
-        altinnTilganger.altinnOrganisasjonerVedkommendeHarTilgangTil() shouldContainExactlyInAnyOrder listOf(
-            AltinnOrganisasjon(
-                name = "Underenhet",
-                organizationNumber = underenhet,
-                organizationForm = "BEDR",
-                parentOrganizationNumber = overordnetEnhet,
-            ),
-            AltinnOrganisasjon(
-                name = "Overordnet enhet",
-                organizationNumber = overordnetEnhet,
-                organizationForm = "ORG",
-                parentOrganizationNumber = "",
-            ),
-        )
-        altinnTilganger.altinnOrganisasjonerVedkommendeHarEnkeltrettighetTil(
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
-            enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
-        ) shouldBe listOf(
-            AltinnOrganisasjon(
-                name = "Underenhet",
-                organizationNumber = underenhet,
-                organizationForm = "BEDR",
-                parentOrganizationNumber = overordnetEnhet,
-            ),
-        )
     }
 
     @Test
@@ -246,13 +190,12 @@ class AltinnTilgangerServiceUnitTest {
             overordnetEnhet = EnkeltrettigheterTilEnVirksomhet(
                 orgnr = overordnetEnhet,
                 navn = "Overordnet enhet",
-                enkeltrettigheterAltinn2 = emptySet(),
+                enkeltrettigheterAltinn3 = emptySet(),
             ),
             underenheter = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhet,
                     navn = "Underenhet",
-                    enkeltrettigheterAltinn2 = setOf("En annen enkelrettighet"),
                     enkeltrettigheterAltinn3 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3),
                 ),
             ),
@@ -273,52 +216,6 @@ class AltinnTilgangerServiceUnitTest {
             ),
         )
         altinnTilganger.altinnOrganisasjonerVedkommendeHarEnkeltrettighetTil(
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
-            enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
-        ) shouldBe listOf(
-            AltinnOrganisasjon(
-                name = "Underenhet",
-                organizationNumber = underenhet,
-                organizationForm = "BEDR",
-                parentOrganizationNumber = overordnetEnhet,
-            ),
-        )
-    }
-
-    @Test
-    fun `listen av AltinnVirksomheter en bruker har tilgang til inneholder riktige virksomheter (med Altinn 2 og Altinn 3)`() {
-        val altinnTilganger = lagAltinnTilganger(
-            overordnetEnhet = EnkeltrettigheterTilEnVirksomhet(
-                orgnr = overordnetEnhet,
-                navn = "Overordnet enhet",
-                enkeltrettigheterAltinn2 = emptySet(),
-            ),
-            underenheter = listOf(
-                EnkeltrettigheterTilEnVirksomhet(
-                    orgnr = underenhet,
-                    navn = "Underenhet",
-                    enkeltrettigheterAltinn2 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2),
-                    enkeltrettigheterAltinn3 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3),
-                ),
-            ),
-        )
-
-        altinnTilganger.altinnOrganisasjonerVedkommendeHarTilgangTil() shouldContainExactlyInAnyOrder listOf(
-            AltinnOrganisasjon(
-                name = "Underenhet",
-                organizationNumber = underenhet,
-                organizationForm = "BEDR",
-                parentOrganizationNumber = overordnetEnhet,
-            ),
-            AltinnOrganisasjon(
-                name = "Overordnet enhet",
-                organizationNumber = overordnetEnhet,
-                organizationForm = "ORG",
-                parentOrganizationNumber = "",
-            ),
-        )
-        altinnTilganger.altinnOrganisasjonerVedkommendeHarEnkeltrettighetTil(
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
             enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
         ) shouldBe listOf(
             AltinnOrganisasjon(
@@ -336,25 +233,25 @@ class AltinnTilgangerServiceUnitTest {
             overordnetEnhet = EnkeltrettigheterTilEnVirksomhet(
                 orgnr = overordnetEnhet,
                 navn = "Overordnet enhet",
-                enkeltrettigheterAltinn2 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2),
+                enkeltrettigheterAltinn3 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3),
             ),
             underenheter = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhet,
                     navn = "Underenhet",
-                    enkeltrettigheterAltinn2 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2),
+                    enkeltrettigheterAltinn3 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3),
                 ),
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhet2,
                     navn = "Underenhet 2",
-                    enkeltrettigheterAltinn2 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2),
+                    enkeltrettigheterAltinn3 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3),
                 ),
             ),
             underenheterNivå2 = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhetNivå2,
                     navn = "Underenhet nivå 2",
-                    enkeltrettigheterAltinn2 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2),
+                    enkeltrettigheterAltinn3 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3),
                 ),
             ),
         )
@@ -386,35 +283,33 @@ class AltinnTilgangerServiceUnitTest {
             ),
         )
         altinnTilganger.altinnOrganisasjonerVedkommendeHarEnkeltrettighetTil(
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
             enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
-        ) shouldContainExactlyInAnyOrder
-            listOf(
-                AltinnOrganisasjon(
-                    name = "Underenhet",
-                    organizationNumber = underenhet,
-                    organizationForm = "BEDR",
-                    parentOrganizationNumber = overordnetEnhet,
-                ),
-                AltinnOrganisasjon(
-                    name = "Underenhet 2",
-                    organizationNumber = underenhet2,
-                    organizationForm = "BEDR",
-                    parentOrganizationNumber = overordnetEnhet,
-                ),
-                AltinnOrganisasjon(
-                    name = "Underenhet nivå 2",
-                    organizationNumber = underenhetNivå2,
-                    organizationForm = "BEDR",
-                    parentOrganizationNumber = underenhet,
-                ),
-                AltinnOrganisasjon(
-                    name = "Overordnet enhet",
-                    organizationNumber = overordnetEnhet,
-                    organizationForm = "ORG",
-                    parentOrganizationNumber = "",
-                ),
-            )
+        ) shouldContainExactlyInAnyOrder listOf(
+            AltinnOrganisasjon(
+                name = "Underenhet",
+                organizationNumber = underenhet,
+                organizationForm = "BEDR",
+                parentOrganizationNumber = overordnetEnhet,
+            ),
+            AltinnOrganisasjon(
+                name = "Underenhet 2",
+                organizationNumber = underenhet2,
+                organizationForm = "BEDR",
+                parentOrganizationNumber = overordnetEnhet,
+            ),
+            AltinnOrganisasjon(
+                name = "Underenhet nivå 2",
+                organizationNumber = underenhetNivå2,
+                organizationForm = "BEDR",
+                parentOrganizationNumber = underenhet,
+            ),
+            AltinnOrganisasjon(
+                name = "Overordnet enhet",
+                organizationNumber = overordnetEnhet,
+                organizationForm = "ORG",
+                parentOrganizationNumber = "",
+            ),
+        )
     }
 
     @Test
@@ -423,32 +318,32 @@ class AltinnTilgangerServiceUnitTest {
             overordnetEnhet = EnkeltrettigheterTilEnVirksomhet(
                 orgnr = overordnetEnhet,
                 navn = "Overordnet enhet",
-                enkeltrettigheterAltinn2 = setOf("En annen enkelrettighet"),
+                enkeltrettigheterAltinn3 = setOf("En annen enkelrettighet"),
             ),
             underenheter = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhet,
                     navn = "Underenhet",
-                    enkeltrettigheterAltinn2 = setOf("En annen enkelrettighet"),
+                    enkeltrettigheterAltinn3 = setOf("En annen enkelrettighet"),
                 ),
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhet2,
                     navn = "Underenhet 2",
-                    enkeltrettigheterAltinn2 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2),
+                    enkeltrettigheterAltinn3 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3),
                 ),
             ),
             underenheterNivå2 = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhetNivå2,
                     navn = "Underenhet nivå 2",
-                    enkeltrettigheterAltinn2 = setOf("En annen enkelrettighet"),
+                    enkeltrettigheterAltinn3 = setOf("En annen enkelrettighet"),
                 ),
             ),
             underenheterNivå3 = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhetNivå3,
                     navn = "Underenhet nivå 3",
-                    enkeltrettigheterAltinn2 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2),
+                    enkeltrettigheterAltinn3 = setOf(ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3),
                 ),
             ),
         )
@@ -486,23 +381,21 @@ class AltinnTilgangerServiceUnitTest {
             ),
         )
         altinnTilganger.altinnOrganisasjonerVedkommendeHarEnkeltrettighetTil(
-            enkeltrettighetIAltinn2 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2,
             enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3,
-        ) shouldContainExactlyInAnyOrder
-            listOf(
-                AltinnOrganisasjon(
-                    name = "Underenhet 2",
-                    organizationNumber = underenhet2,
-                    organizationForm = "BEDR",
-                    parentOrganizationNumber = overordnetEnhet,
-                ),
-                AltinnOrganisasjon(
-                    name = "Underenhet nivå 3",
-                    organizationNumber = underenhetNivå3,
-                    organizationForm = "BEDR",
-                    parentOrganizationNumber = underenhetNivå2,
-                ),
-            )
+        ) shouldContainExactlyInAnyOrder listOf(
+            AltinnOrganisasjon(
+                name = "Underenhet 2",
+                organizationNumber = underenhet2,
+                organizationForm = "BEDR",
+                parentOrganizationNumber = overordnetEnhet,
+            ),
+            AltinnOrganisasjon(
+                name = "Underenhet nivå 3",
+                organizationNumber = underenhetNivå3,
+                organizationForm = "BEDR",
+                parentOrganizationNumber = underenhetNivå2,
+            ),
+        )
     }
 
     @Test
@@ -511,13 +404,13 @@ class AltinnTilgangerServiceUnitTest {
             overordnetEnhet = EnkeltrettigheterTilEnVirksomhet(
                 orgnr = overordnetEnhet,
                 navn = "Overordnet enhet",
-                enkeltrettigheterAltinn2 = setOf("En annen enkelrettighet"),
+                enkeltrettigheterAltinn3 = setOf("En annen enkelrettighet"),
             ),
             underenheter = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhet,
                     navn = "Underenhet",
-                    enkeltrettigheterAltinn2 = setOf("En annen enkelrettighet"),
+                    enkeltrettigheterAltinn3 = setOf("En annen enkelrettighet"),
                 ),
             ),
         )
@@ -531,27 +424,27 @@ class AltinnTilgangerServiceUnitTest {
             overordnetEnhet = EnkeltrettigheterTilEnVirksomhet(
                 orgnr = overordnetEnhet,
                 navn = "Overordnet enhet",
-                enkeltrettigheterAltinn2 = setOf("En annen enkelrettighet"),
+                enkeltrettigheterAltinn3 = setOf("En annen enkelrettighet"),
             ),
             underenheter = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhet,
                     navn = "Underenhet",
-                    enkeltrettigheterAltinn2 = setOf("En annen enkelrettighet"),
+                    enkeltrettigheterAltinn3 = setOf("En annen enkelrettighet"),
                 ),
             ),
             underenheterNivå2 = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhetNivå2,
                     navn = "Underenhet nivå 2",
-                    enkeltrettigheterAltinn2 = setOf("En annen enkelrettighet"),
+                    enkeltrettigheterAltinn3 = setOf("En annen enkelrettighet"),
                 ),
             ),
             underenheterNivå3 = listOf(
                 EnkeltrettigheterTilEnVirksomhet(
                     orgnr = underenhetNivå3,
                     navn = "Underenhet nivå 3",
-                    enkeltrettigheterAltinn2 = setOf("En annen enkelrettighet"),
+                    enkeltrettigheterAltinn3 = setOf("En annen enkelrettighet"),
                 ),
             ),
         )
@@ -561,76 +454,86 @@ class AltinnTilgangerServiceUnitTest {
         altinnTilganger.finnOverordnetEnhet(underenhetNivå3) shouldBe underenhetNivå2
     }
 
+    @Test
+    fun `verif fra en use-case i dev miljø`() {
+        val altinnTilganger = Json.decodeFromString<AltinnTilganger>(jsonResponseFraAltinnTilgangerIDevMiljø)
+
+        altinnTilganger.harTilgangTilOrgnr(orgnr = "310529915") shouldBe true
+        altinnTilganger.harTilgangTilOrgnr(orgnr = "313068420") shouldBe true
+        altinnTilganger.harEnkeltrettighetIAltinn3(
+            orgnr = "313068420",
+            enkeltrettighetIAltinn3 = ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3
+        ) shouldBe false
+    }
+
     private fun lagAltinnTilganger(
         overordnetEnhet: EnkeltrettigheterTilEnVirksomhet,
         underenheter: List<EnkeltrettigheterTilEnVirksomhet>,
         underenheterNivå2: List<EnkeltrettigheterTilEnVirksomhet> = emptyList(),
         underenheterNivå3: List<EnkeltrettigheterTilEnVirksomhet> = emptyList(),
-    ): AltinnTilganger =
-        AltinnTilganger(
-            hierarki = listOf(
-                AltinnTilgang(
-                    overordnetEnhet.orgnr,
-                    altinn2Tilganger = overordnetEnhet.enkeltrettigheterAltinn2,
-                    altinn3Tilganger = overordnetEnhet.enkeltrettigheterAltinn3,
-                    navn = overordnetEnhet.navn,
-                    organisasjonsform = "ORG",
-                    underenheter = listOf(
-                        AltinnTilgang(
-                            orgnr = underenheter.first().orgnr,
-                            altinn2Tilganger = underenheter.first().enkeltrettigheterAltinn2,
-                            altinn3Tilganger = underenheter.first().enkeltrettigheterAltinn3,
-                            navn = underenheter.first().navn,
-                            underenheter = if (underenheterNivå2.isNotEmpty()) {
-                                underenheterNivå2.map { underenhetNivå2 ->
-                                    AltinnTilgang(
-                                        orgnr = underenhetNivå2.orgnr,
-                                        altinn2Tilganger = underenhetNivå2.enkeltrettigheterAltinn2,
-                                        altinn3Tilganger = underenhetNivå2.enkeltrettigheterAltinn3,
-                                        navn = underenhetNivå2.navn,
-                                        underenheter = if (underenheterNivå3.isNotEmpty()) {
-                                            underenheterNivå3.map { underenhetNivå3 ->
-                                                AltinnTilgang(
-                                                    orgnr = underenhetNivå3.orgnr,
-                                                    altinn2Tilganger = underenhetNivå3.enkeltrettigheterAltinn2,
-                                                    altinn3Tilganger = underenhetNivå3.enkeltrettigheterAltinn3,
-                                                    navn = underenhetNivå3.navn,
-                                                    underenheter = emptyList(),
-                                                    organisasjonsform = "BEDR",
-                                                )
-                                            }
-                                        } else {
-                                            emptyList()
-                                        },
-                                        organisasjonsform = "BEDR",
-                                    )
-                                }
-                            } else {
-                                emptyList()
-                            },
-                            organisasjonsform = "BEDR",
-                        ),
-                    ).plus(
-                        underenheter.drop(1).map { underenhet ->
-                            AltinnTilgang(
-                                orgnr = underenhet.orgnr,
-                                altinn2Tilganger = underenhet.enkeltrettigheterAltinn2,
-                                altinn3Tilganger = underenhet.enkeltrettigheterAltinn3,
-                                navn = underenhet.navn,
-                                underenheter = emptyList(),
-                                organisasjonsform = "BEDR",
-                            )
+    ): AltinnTilganger = AltinnTilganger(
+        hierarki = listOf(
+            AltinnTilgang(
+                overordnetEnhet.orgnr,
+                altinn2Tilganger = emptySet(),
+                altinn3Tilganger = overordnetEnhet.enkeltrettigheterAltinn3,
+                navn = overordnetEnhet.navn,
+                organisasjonsform = "ORG",
+                underenheter = listOf(
+                    AltinnTilgang(
+                        orgnr = underenheter.first().orgnr,
+                        altinn2Tilganger = emptySet(),
+                        altinn3Tilganger = underenheter.first().enkeltrettigheterAltinn3,
+                        navn = underenheter.first().navn,
+                        underenheter = if (underenheterNivå2.isNotEmpty()) {
+                            underenheterNivå2.map { underenhetNivå2 ->
+                                AltinnTilgang(
+                                    orgnr = underenhetNivå2.orgnr,
+                                    altinn2Tilganger = emptySet(),
+                                    altinn3Tilganger = underenhetNivå2.enkeltrettigheterAltinn3,
+                                    navn = underenhetNivå2.navn,
+                                    underenheter = if (underenheterNivå3.isNotEmpty()) {
+                                        underenheterNivå3.map { underenhetNivå3 ->
+                                            AltinnTilgang(
+                                                orgnr = underenhetNivå3.orgnr,
+                                                altinn2Tilganger = emptySet(),
+                                                altinn3Tilganger = underenhetNivå3.enkeltrettigheterAltinn3,
+                                                navn = underenhetNivå3.navn,
+                                                underenheter = emptyList(),
+                                                organisasjonsform = "BEDR",
+                                            )
+                                        }
+                                    } else {
+                                        emptyList()
+                                    },
+                                    organisasjonsform = "BEDR",
+                                )
+                            }
+                        } else {
+                            emptyList()
                         },
+                        organisasjonsform = "BEDR",
                     ),
+                ).plus(
+                    underenheter.drop(1).map { underenhet ->
+                        AltinnTilgang(
+                            orgnr = underenhet.orgnr,
+                            altinn2Tilganger = emptySet(),
+                            altinn3Tilganger = underenhet.enkeltrettigheterAltinn3,
+                            navn = underenhet.navn,
+                            underenheter = emptyList(),
+                            organisasjonsform = "BEDR",
+                        )
+                    },
                 ),
             ),
-            orgNrTilTilganger = mapOf(
-                overordnetEnhet.orgnr to overordnetEnhet.enkeltrettigheterAltinn2.plus(overordnetEnhet.enkeltrettigheterAltinn3),
-            ).plus(underenheter.toPair()).plus(underenheterNivå2.toPair()),
-            tilgangTilOrgNr = listOf(overordnetEnhet).plus(underenheter).plus(underenheterNivå2)
-                .splitByEnkeltrettighet(),
-            isError = false,
-        )
+        ),
+        orgNrTilTilganger = mapOf(
+            overordnetEnhet.orgnr to overordnetEnhet.enkeltrettigheterAltinn3
+        ).plus(underenheter.toPair()).plus(underenheterNivå2.toPair()),
+        tilgangTilOrgNr = listOf(overordnetEnhet).plus(underenheter).plus(underenheterNivå2).splitByEnkeltrettighet(),
+        isError = false,
+    )
 
     @Test
     fun `Selftest -- splitByEnkeltrettighet`() {
@@ -638,22 +541,22 @@ class AltinnTilgangerServiceUnitTest {
             EnkeltrettigheterTilEnVirksomhet(
                 orgnr = "111111111",
                 navn = "Test 1",
-                enkeltrettigheterAltinn2 = setOf("ENKELRETTIGHET_1"),
+                enkeltrettigheterAltinn3 = setOf("ENKELRETTIGHET_1"),
             ),
             EnkeltrettigheterTilEnVirksomhet(
                 orgnr = "222222222",
                 navn = "Test 2",
-                enkeltrettigheterAltinn2 = setOf("ENKELRETTIGHET_1", "ENKELRETTIGHET_2"),
+                enkeltrettigheterAltinn3 = setOf("ENKELRETTIGHET_1", "ENKELRETTIGHET_2"),
             ),
             EnkeltrettigheterTilEnVirksomhet(
                 orgnr = "333333333",
                 navn = "Test 3",
-                enkeltrettigheterAltinn2 = setOf("ENKELRETTIGHET_3", "ENKELRETTIGHET_2"),
+                enkeltrettigheterAltinn3 = setOf("ENKELRETTIGHET_3", "ENKELRETTIGHET_2"),
             ),
             EnkeltrettigheterTilEnVirksomhet(
                 orgnr = "444444444",
                 navn = "Test 4",
-                enkeltrettigheterAltinn2 = setOf("ENKELRETTIGHET_4"),
+                enkeltrettigheterAltinn3 = setOf("ENKELRETTIGHET_4"),
             ),
         )
         liste.splitByEnkeltrettighet() shouldBe mapOf(
@@ -667,16 +570,13 @@ class AltinnTilgangerServiceUnitTest {
     private data class EnkeltrettigheterTilEnVirksomhet(
         val orgnr: String,
         val navn: String,
-        val enkeltrettigheterAltinn2: Set<String>,
         val enkeltrettigheterAltinn3: Set<String> = emptySet(),
     )
 
-    private fun List<EnkeltrettigheterTilEnVirksomhet>.toPair(): Map<String, Set<String>> = this.associate { it.toPair() }
+    private fun List<EnkeltrettigheterTilEnVirksomhet>.toPair(): Map<String, Set<String>> =
+        this.associate { it.toPair() }
 
-    private fun EnkeltrettigheterTilEnVirksomhet.toPair(): Pair<String, Set<String>> =
-        orgnr to enkeltrettigheterAltinn2.plus(
-            enkeltrettigheterAltinn3,
-        )
+    private fun EnkeltrettigheterTilEnVirksomhet.toPair(): Pair<String, Set<String>> = orgnr to enkeltrettigheterAltinn3
 
     private fun List<EnkeltrettigheterTilEnVirksomhet>.splitByEnkeltrettighet(): Map<String, Set<String>> =
         this.associate { it.toPair() }.flatMap { (orgnr, enkeltrettigheter) ->

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/auth/AltinnTilgangerTestCase.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/api/auth/AltinnTilgangerTestCase.kt
@@ -1,0 +1,344 @@
+package no.nav.pia.sykefravarsstatistikk.api.auth
+
+class AltinnTilgangerTestCase {
+    companion object {
+
+        // Respons fra arbeidsgiver-altinn-tilganger i dev-miljø: https://arbeidsgiver-altinn-tilganger.intern.dev.nav.no/swagger-ui#
+        val jsonResponseFraAltinnTilgangerIDevMiljø: String = """
+            {
+              "isError": false,
+              "hierarki": [
+                {
+                  "orgnr": "310529915",
+                  "altinn3Tilganger": [
+                    "nav_forebygge-og-redusere-sykefravar_samarbeid",
+                    "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk",
+                    "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
+                    "nav_sosialtjenester_digisos-avtale"
+                  ],
+                  "altinn2Tilganger": [
+                    "5934:1",
+                    "3403:1",
+                    "5810:1",
+                    "5867:1",
+                    "2896:87",
+                    "5516:3",
+                    "5516:1",
+                    "5516:4",
+                    "5441:1",
+                    "5516:6",
+                    "5384:1",
+                    "5516:5",
+                    "5332:1",
+                    "5516:2",
+                    "4826:1",
+                    "4936:1",
+                    "5278:1",
+                    "5078:1",
+                    "5902:1"
+                  ],
+                  "underenheter": [
+                    {
+                      "orgnr": "311874411",
+                      "altinn3Tilganger": [
+                        "nav_forebygge-og-redusere-sykefravar_samarbeid",
+                        "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk",
+                        "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
+                        "nav_sosialtjenester_digisos-avtale"
+                      ],
+                      "altinn2Tilganger": [
+                        "5934:1",
+                        "3403:1",
+                        "5810:1",
+                        "5867:1",
+                        "2896:87",
+                        "5516:3",
+                        "5516:1",
+                        "5516:4",
+                        "5441:1",
+                        "5516:6",
+                        "5384:1",
+                        "5516:5",
+                        "5332:1",
+                        "5516:2",
+                        "4826:1",
+                        "4936:1",
+                        "5278:1",
+                        "5078:1",
+                        "5902:1"
+                      ],
+                      "underenheter": [],
+                      "navn": "SPISS SJOKKERT TIGER AS",
+                      "organisasjonsform": "BEDR"
+                    }
+                  ],
+                  "navn": "SPISS SJOKKERT TIGER AS",
+                  "organisasjonsform": "AS"
+                },
+                {
+                  "orgnr": "313068420",
+                  "altinn3Tilganger": [
+                    "nav_forebygge-og-redusere-sykefravar_samarbeid"
+                  ],
+                  "altinn2Tilganger": [
+                    "5934:1",
+                    "4826:1",
+                    "4936:1",
+                    "5078:1",
+                    "5902:1"
+                  ],
+                  "underenheter": [
+                    {
+                      "orgnr": "315829062",
+                      "altinn3Tilganger": [
+                        "nav_forebygge-og-redusere-sykefravar_samarbeid"
+                      ],
+                      "altinn2Tilganger": [
+                        "5934:1",
+                        "4826:1",
+                        "4936:1",
+                        "5078:1",
+                        "5902:1"
+                      ],
+                      "underenheter": [],
+                      "navn": "TILLITSFULL PEN TIGER AS",
+                      "organisasjonsform": "BEDR"
+                    }
+                  ],
+                  "navn": "TILLITSFULL PEN TIGER AS",
+                  "organisasjonsform": "AS"
+                },
+                {
+                  "orgnr": "310807176",
+                  "altinn3Tilganger": [
+                    "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
+                  ],
+                  "altinn2Tilganger": [
+                    "3403:1"
+                  ],
+                  "underenheter": [],
+                  "navn": "UVITENDE SNILL TIGER AS",
+                  "organisasjonsform": "AS"
+                },
+                {
+                  "orgnr": "313901637",
+                  "altinn3Tilganger": [
+                    "nav_forebygge-og-redusere-sykefravar_samarbeid"
+                  ],
+                  "altinn2Tilganger": [
+                    "5934:1"
+                  ],
+                  "underenheter": [
+                    {
+                      "orgnr": "311284568",
+                      "altinn3Tilganger": [
+                        "nav_forebygge-og-redusere-sykefravar_samarbeid"
+                      ],
+                      "altinn2Tilganger": [
+                        "5934:1"
+                      ],
+                      "underenheter": [],
+                      "navn": "ÆRLIG EKSPLOSIV TIGER AS",
+                      "organisasjonsform": "BEDR"
+                    }
+                  ],
+                  "navn": "ÆRLIG EKSPLOSIV TIGER AS",
+                  "organisasjonsform": "AS"
+                }
+              ],
+              "orgNrTilTilganger": {
+                "310529915": [
+                  "5934:1",
+                  "3403:1",
+                  "5810:1",
+                  "5867:1",
+                  "2896:87",
+                  "5516:3",
+                  "5516:1",
+                  "5516:4",
+                  "5441:1",
+                  "5516:6",
+                  "5384:1",
+                  "5516:5",
+                  "5332:1",
+                  "5516:2",
+                  "4826:1",
+                  "4936:1",
+                  "5278:1",
+                  "5078:1",
+                  "5902:1",
+                  "nav_forebygge-og-redusere-sykefravar_samarbeid",
+                  "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk",
+                  "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
+                  "nav_sosialtjenester_digisos-avtale"
+                ],
+                "310807176": [
+                  "3403:1",
+                  "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
+                ],
+                "311284568": [
+                  "5934:1",
+                  "nav_forebygge-og-redusere-sykefravar_samarbeid"
+                ],
+                "311874411": [
+                  "5934:1",
+                  "3403:1",
+                  "5810:1",
+                  "5867:1",
+                  "2896:87",
+                  "5516:3",
+                  "5516:1",
+                  "5516:4",
+                  "5441:1",
+                  "5516:6",
+                  "5384:1",
+                  "5516:5",
+                  "5332:1",
+                  "5516:2",
+                  "4826:1",
+                  "4936:1",
+                  "5278:1",
+                  "5078:1",
+                  "5902:1",
+                  "nav_forebygge-og-redusere-sykefravar_samarbeid",
+                  "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk",
+                  "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger",
+                  "nav_sosialtjenester_digisos-avtale"
+                ],
+                "313068420": [
+                  "5934:1",
+                  "4826:1",
+                  "4936:1",
+                  "5078:1",
+                  "5902:1",
+                  "nav_forebygge-og-redusere-sykefravar_samarbeid"
+                ],
+                "313901637": [
+                  "5934:1",
+                  "nav_forebygge-og-redusere-sykefravar_samarbeid"
+                ],
+                "315829062": [
+                  "5934:1",
+                  "4826:1",
+                  "4936:1",
+                  "5078:1",
+                  "5902:1",
+                  "nav_forebygge-og-redusere-sykefravar_samarbeid"
+                ]
+              },
+              "tilgangTilOrgNr": {
+                "5934:1": [
+                  "310529915",
+                  "311874411",
+                  "313068420",
+                  "315829062",
+                  "313901637",
+                  "311284568"
+                ],
+                "3403:1": [
+                  "310529915",
+                  "311874411",
+                  "310807176"
+                ],
+                "5810:1": [
+                  "310529915",
+                  "311874411"
+                ],
+                "5867:1": [
+                  "310529915",
+                  "311874411"
+                ],
+                "2896:87": [
+                  "310529915",
+                  "311874411"
+                ],
+                "5516:3": [
+                  "310529915",
+                  "311874411"
+                ],
+                "5516:1": [
+                  "310529915",
+                  "311874411"
+                ],
+                "5516:4": [
+                  "310529915",
+                  "311874411"
+                ],
+                "5441:1": [
+                  "310529915",
+                  "311874411"
+                ],
+                "5516:6": [
+                  "310529915",
+                  "311874411"
+                ],
+                "5384:1": [
+                  "310529915",
+                  "311874411"
+                ],
+                "5516:5": [
+                  "310529915",
+                  "311874411"
+                ],
+                "5332:1": [
+                  "310529915",
+                  "311874411"
+                ],
+                "5516:2": [
+                  "310529915",
+                  "311874411"
+                ],
+                "4826:1": [
+                  "310529915",
+                  "311874411",
+                  "313068420",
+                  "315829062"
+                ],
+                "4936:1": [
+                  "310529915",
+                  "311874411",
+                  "313068420",
+                  "315829062"
+                ],
+                "5278:1": [
+                  "310529915",
+                  "311874411"
+                ],
+                "5078:1": [
+                  "310529915",
+                  "311874411",
+                  "313068420",
+                  "315829062"
+                ],
+                "5902:1": [
+                  "310529915",
+                  "311874411",
+                  "313068420",
+                  "315829062"
+                ],
+                "nav_forebygge-og-redusere-sykefravar_samarbeid": [
+                  "310529915",
+                  "311874411",
+                  "313068420",
+                  "315829062",
+                  "313901637",
+                  "311284568"
+                ],
+                "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk": [
+                  "310529915",
+                  "311874411",
+                  "310807176"
+                ],
+                "nav_permittering-og-nedbemmaning_innsyn-i-alle-innsendte-meldinger": [
+                  "310529915",
+                  "311874411"
+                ],
+                "nav_sosialtjenester_digisos-avtale": [
+                  "310529915",
+                  "311874411"
+                ]
+              }
+            }
+        """.trimIndent()
+    }
+}

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/helper/AltinnTilgangerContainerHelper.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/helper/AltinnTilgangerContainerHelper.kt
@@ -91,7 +91,7 @@ class AltinnTilgangerContainerHelper(
         underenhet: Underenhet,
         altinn3Rettighet: String = "nav-ia-sykefravarsstatistikk-IKKE-SATT-OPP-ENDA",
     ) {
-        val altinn2Rettighet: String = ""
+        val altinn2Rettighet = ""
         log.info("Legger til rettigheter [altinn2: '$altinn2Rettighet' og altinn3: '$altinn3Rettighet'] for underenhet '${underenhet.orgnr}'")
         val client = getMockServerClient()
         runBlocking {

--- a/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/helper/TestdataHelper.kt
+++ b/src/test/kotlin/no/nav/pia/sykefravarsstatistikk/helper/TestdataHelper.kt
@@ -30,7 +30,6 @@ import java.math.BigDecimal
 class TestdataHelper {
     companion object {
         // Variabler som kan brukes hvor det ikke er behov for å starte TestContainers (unit tester)
-        const val ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_2 = "3403:1"
         const val ENKELRETTIGHET_SYKEFRAVÆRSSTATISTIKK_ALTINN_3 =
             "nav_forebygge-og-redusere-sykefravar_sykefravarsstatistikk"
 


### PR DESCRIPTION
Vi trenger ikke lenger å verifisere mot Altinn 2 (service code / service edition) 
Endringer: 
 - fjerne (nesten alle) referanser/kode til Altinn 2 service code / service edition
 - fjerne i koden sjekk på `altinn2Tilganger` i `AltinnTilgang` objekt  (objektet som `arbeidsgiver-altinn-tilganger`api returnerer)
 - beholde metrics på antall altinn2tilganger vs altinn3tilganger (i hvertfal en stund til)  