### PR TITLE
Oppdater ACL (Access Control List) for noen topics

### DIFF
--- a/.nais/topics/sykefravarsstatistikk-bransje-topic.yaml
+++ b/.nais/topics/sykefravarsstatistikk-bransje-topic.yaml
@@ -20,7 +20,13 @@ spec:
       access: readwrite   # read, write, readwrite
     - team: pia
       application: lydia-api
-      access: read # read, write, readwrite
+      access: read
     - team: pia
       application: pia-devops
+      access: read
+    - team: fager
+      application: min-side-arbeidsgiver-api
+      access: read
+    - team: team-dialog
+      application: sf-sykefravarsstatistikk-bransje
       access: read

--- a/.nais/topics/sykefravarsstatistikk-land-topic.yaml
+++ b/.nais/topics/sykefravarsstatistikk-land-topic.yaml
@@ -24,3 +24,6 @@ spec:
     - team: pia
       application: pia-devops
       access: read
+    - team: team-dialog
+      application: sf-sykefravarsstatistikk-land
+      access: read

--- a/.nais/topics/sykefravarsstatistikk-metadata-virksomhet-topic.yaml
+++ b/.nais/topics/sykefravarsstatistikk-metadata-virksomhet-topic.yaml
@@ -24,3 +24,9 @@ spec:
     - team: pia
       application: pia-devops
       access: read
+    - team: fager
+      application: min-side-arbeidsgiver-api
+      access: read
+    - team: team-dialog
+      application: sf-sykefravarsstatistikk-metadata
+      access: read

--- a/.nais/topics/sykefravarsstatistikk-naring-topic.yaml
+++ b/.nais/topics/sykefravarsstatistikk-naring-topic.yaml
@@ -24,3 +24,9 @@ spec:
     - team: pia
       application: pia-devops
       access: read
+    - team: fager
+      application: min-side-arbeidsgiver-api
+      access: read
+    - team: team-dialog
+      application: sf-sykefravarsstatistikk-naring
+      access: read

--- a/.nais/topics/sykefravarsstatistikk-naringskode-topic.yaml
+++ b/.nais/topics/sykefravarsstatistikk-naringskode-topic.yaml
@@ -24,3 +24,6 @@ spec:
     - team: pia
       application: pia-devops
       access: read
+    - team: team-dialog
+      application: sf-sykefravarsstatistikk-naringskode
+      access: read

--- a/.nais/topics/sykefravarsstatistikk-sektor-topic.yaml
+++ b/.nais/topics/sykefravarsstatistikk-sektor-topic.yaml
@@ -24,3 +24,6 @@ spec:
     - team: pia
       application: pia-devops
       access: read
+    - team: team-dialog
+      application: sf-sykefravarsstatistikk-sektor
+      access: read

--- a/.nais/topics/sykefravarsstatistikk-virksomhet-topic.yaml
+++ b/.nais/topics/sykefravarsstatistikk-virksomhet-topic.yaml
@@ -24,3 +24,9 @@ spec:
     - team: pia
       application: pia-devops
       access: read
+    - team: fager
+      application: min-side-arbeidsgiver-api
+      access: read
+    - team: team-dialog
+      application: sf-sykefravarsstatistikk-virksomhet
+      access: read


### PR DESCRIPTION
Oppdater ACL (Access Control List) for noen topics for sykefraværsstatistikk, slik at min-side-arbeidsgiver-api (Fager) og sf-sykefravarsstatistikk (Dialog/SF) kan konsummere statistikk data
Fager + Dialog:
 - sykefravarsstatistikk-bransje-v1 
 - sykefravarsstatistikk-metadata-virksomhet-v1 
 - sykefravarsstatistikk-naring-v1
 - sykefravarsstatistikk-virksomhet-v1 
Dialog: 
 - sykefravarsstatistikk-land-v1 
 - sykefravarsstatistikk-naringskode-v1 
 - sykefravarsstatistikk-sektor-v1